### PR TITLE
feat: support roberta

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,19 @@ Benchmark for [BAAI/bge-base-en-v1.5](https://huggingface.co/BAAI/bge-base-en-v1
 
 ## Table of contents
 
-- [Get Started](#get-started)
-  - [Supported Models](#supported-models)
-  - [Docker](#docker)
-  - [Docker Images](#docker-images)
-  - [API Documentation](#api-documentation)
-  - [Using a private or gated model](#using-a-private-or-gated-model)
-  - [Distributed Tracing](#distributed-tracing)
-- [Local Install](#local-install)
-- [Docker Build](#docker-build)
+- [Text Embeddings Inference](#text-embeddings-inference)
+  - [Table of contents](#table-of-contents)
+  - [Get Started](#get-started)
+    - [Supported Models](#supported-models)
+    - [Docker](#docker)
+    - [Docker Images](#docker-images)
+    - [API documentation](#api-documentation)
+    - [Using a private or gated model](#using-a-private-or-gated-model)
+    - [Distributed Tracing](#distributed-tracing)
+  - [Local install](#local-install)
+    - [CPU](#cpu)
+    - [Cuda](#cuda)
+  - [Docker build](#docker-build)
 
 Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings models. TEI enables
 high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5. TEI implements many features
@@ -53,8 +57,7 @@ such as:
 
 ### Supported Models
 
-You can use any JinaBERT model with Alibi or absolute positions or any BERT, CamemBERT or XLM-RoBERTa model with 
-absolute positions in `text-embeddings-inference`. 
+You can use any JinaBERT model with Alibi or absolute positions or any BERT, CamemBERT, RoBERTa, or XLM-RoBERTa model with absolute positions in `text-embeddings-inference`.
 
 **Support for other model types will be added in the future.**
 
@@ -96,8 +99,8 @@ curl 127.0.0.1:8080/embed \
     -H 'Content-Type: application/json'
 ```
 
-**Note:** To use GPUs, you need to install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html). 
-We also recommend using NVIDIA drivers with CUDA version 12.0 or higher. 
+**Note:** To use GPUs, you need to install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html).
+We also recommend using NVIDIA drivers with CUDA version 12.0 or higher.
 
 To see all options to serve your models:
 
@@ -236,7 +239,7 @@ Text Embeddings Inference ships with multiple Docker images that you can use to 
 | Ada Lovelace (RTX 4000 series, ...) | ghcr.io/huggingface/text-embeddings-inference:89-0.3.0                    |
 | Hopper (H100)                       | ghcr.io/huggingface/text-embeddings-inference:hopper-0.3.0 (experimental) |
 
-**Warning**: Flash Attention is turned off by default for the Turing image as it suffers from precision issues. 
+**Warning**: Flash Attention is turned off by default for the Turing image as it suffers from precision issues.
 You can turn Flash Attention v1 ON by using the `USE_FLASH_ATTENTION=True` environment variable.
 
 ### API documentation
@@ -329,7 +332,7 @@ cargo install --path router -F candle-cuda-turing --no-default-features
 cargo install --path router -F candle-cuda --no-default-features
 ```
 
-You can now launch Text Embeddings Inference on GPU with: 
+You can now launch Text Embeddings Inference on GPU with:
 
 ```shell
 model=BAAI/bge-large-en-v1.5

--- a/README.md
+++ b/README.md
@@ -26,19 +26,15 @@ Benchmark for [BAAI/bge-base-en-v1.5](https://huggingface.co/BAAI/bge-base-en-v1
 
 ## Table of contents
 
-- [Text Embeddings Inference](#text-embeddings-inference)
-  - [Table of contents](#table-of-contents)
-  - [Get Started](#get-started)
-    - [Supported Models](#supported-models)
-    - [Docker](#docker)
-    - [Docker Images](#docker-images)
-    - [API documentation](#api-documentation)
-    - [Using a private or gated model](#using-a-private-or-gated-model)
-    - [Distributed Tracing](#distributed-tracing)
-  - [Local install](#local-install)
-    - [CPU](#cpu)
-    - [Cuda](#cuda)
-  - [Docker build](#docker-build)
+- [Get Started](#get-started)
+  - [Supported Models](#supported-models)
+  - [Docker](#docker)
+  - [Docker Images](#docker-images)
+  - [API Documentation](#api-documentation)
+  - [Using a private or gated model](#using-a-private-or-gated-model)
+  - [Distributed Tracing](#distributed-tracing)
+- [Local Install](#local-install)
+- [Docker Build](#docker-build)
 
 Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings models. TEI enables
 high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5. TEI implements many features

--- a/backends/candle/src/lib.rs
+++ b/backends/candle/src/lib.rs
@@ -41,6 +41,7 @@ impl CandleBackend {
         if config.model_type != Some("bert".to_string())
             && config.model_type != Some("xlm-roberta".to_string())
             && config.model_type != Some("camembert".to_string())
+            && config.model_type != Some("roberta".to_string())
         {
             return Err(BackendError::Start(format!(
                 "Model {:?} is not supported",

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -215,12 +215,14 @@ async fn main() -> Result<()> {
     tokenizer.with_padding(None);
 
     // Position IDs offset. Used for Roberta and camembert.
-    let position_offset =
-        if &config.model_type == "xlm-roberta" || &config.model_type == "camembert" {
-            config.pad_token_id + 1
-        } else {
-            0
-        };
+    let position_offset = if &config.model_type == "xlm-roberta"
+        || &config.model_type == "camembert"
+        || &config.model_type == "roberta"
+    {
+        config.pad_token_id + 1
+    } else {
+        0
+    };
     let max_input_length = config.max_position_embeddings - position_offset;
 
     let tokenization_workers = args


### PR DESCRIPTION
# What does this PR do?

- [x] Support RoBERTa model. (I just referred #42)

+ (11/5/23) I tested on the CPU env with my RoBERTa model.

# Tests

## On CPU

* OS : Windows 10
* CPU : i7-7700K
* rustc : v1.73.0 stable
* build : `cargo install --path router -F candle -F mkl`

### hf repo files

`roberta-large` model & tokenizer.

![image](https://github.com/huggingface/text-embeddings-inference/assets/15344796/c6837d92-41ec-400d-80f5-c8ffb3c18dfb)

### run server

* pooling : cls
* type : float32 (default)

![image](https://github.com/huggingface/text-embeddings-inference/assets/15344796/a1601fad-e1e0-49fe-8d6b-7a5c6bec6e18)

### output differences

code

```
# load pytorch model on CPU with eval mode.
model = ...

with torch.inference_mode():
    token = tokenizer(
        ['asdf'],
        truncation=True,
        return_tensors='pt',
    )

    pytorch_embedding = model(**token)[0].numpy()  # shape: (1024,)

tei_embedding = np.asarray(
    requests.post(
        'http://localhost:8080/embed', 
        data=json.dumps({'inputs': 'asdf'}), 
        headers={'Content-type': 'application/json'},
    ).json(),
    dtype=np.float32,
)[0, :]  # shape: (1024,)

np.testing.assert_allclose(
    pytorch_embedding,
    tei_embedding,
    rtol=1e-4,
    atol=1e-4,
)
```

maybe, it's due to intel-mkl or type casting (f64, f32) issues?

```
AssertionError: 
Not equal to tolerance rtol=0.0001, atol=0.0001

Mismatched elements: 69 / 1024 (6.74%)
Max absolute difference: 0.00026077
Max relative difference: 1.4665195
 x: array([-0.008894, -0.028655, -0.025436, ...,  0.019459,  0.003749,
        0.022704], dtype=float32)
 y: array([-0.008802, -0.028713, -0.025372, ...,  0.019452,  0.003691,
        0.02279 ], dtype=float32)
```

## On GPU

I don't have any GPUs :(

## Errors

`noah-go/sentence-search-roberta` gives an error like below. maybe some configurations or files are missing.

```
PS C:\Users\zero\Desktop\text-embeddings-inference> text-embeddings-router --model-id noah-go/sentence-search-roberta --port 8080
2023-11-05T02:26:21.654604Z  INFO text_embeddings_router: router\src/main.rs:152: Args { model_id: "noa*-**/********-******-****rta", revision: None, tokenization_workers: None, dtype: None, pooling: None, max_concurrent_requests: 512, max_batch_tokens: 16384, max_batch_requests: None, max_client_batch_size: 32, hf_api_token: None, hostname: "0.0.0.0", port: 8080, uds_path: "/tmp/text-embeddings-inference-server", huggingface_hub_cache: None, json_output: false, otlp_endpoint: None, cors_allow_origin: None }
2023-11-05T02:26:21.657287Z  INFO download_artifacts: text_embeddings_core::download: core\src\download.rs:9: Starting download
2023-11-05T02:26:21.927572Z  WARN download_artifacts: text_embeddings_core::download: core\src\download.rs:15: `model.safetensors` not found. Using `pytorch_model.bin` instead. Model loading will be significantly slower.
2023-11-05T02:26:21.927994Z  INFO download_artifacts: text_embeddings_core::download: core\src\download.rs:25: Model artifacts downloaded in 270.7077ms
2023-11-05T02:26:21.938743Z  INFO text_embeddings_core::tokenization: core\src\tokenization.rs:22: Starting 4 tokenization workers
2023-11-05T02:26:21.958672Z  INFO text_embeddings_router: router\src/main.rs:253: Starting model backend
2023-11-05T02:26:21.961545Z  INFO text_embeddings_backend_candle: backends\candle\src\lib.rs:79: Starting Bert model on CPU
Error: Could not create backend

Caused by:
    Could not start backend: specified file not found in archive
```

## Who can review?

@OlivierDehaene OR @Narsil