### PR TITLE
add Jina Model class to handle Jina variant

### DIFF
--- a/backends/python/server/text_embeddings_server/models/__init__.py
+++ b/backends/python/server/text_embeddings_server/models/__init__.py
@@ -6,8 +6,8 @@ from typing import Optional
 from transformers import AutoConfig
 from transformers.models.bert import BertConfig
 
-from text_embeddings_server.models.model import Model
 from text_embeddings_server.models.default_model import DefaultModel
+from text_embeddings_server.models.jina_model import JinaModel
 
 __all__ = ["Model"]
 
@@ -53,6 +53,8 @@ def get_model(model_path: Path, dtype: Optional[str]):
             and FLASH_ATTENTION
         ):
             return FlashBert(model_path, device, dtype)
+        elif 'JinaBertForMaskedLM' in config.architectures:
+            return JinaModel(model_path, device, dtype)
         else:
             return DefaultModel(model_path, device, dtype)
 

--- a/backends/python/server/text_embeddings_server/models/jina_model.py
+++ b/backends/python/server/text_embeddings_server/models/jina_model.py
@@ -1,0 +1,60 @@
+import inspect
+import torch
+
+from pathlib import Path
+from typing import Type, List
+from transformers import AutoModel
+from opentelemetry import trace
+
+from text_embeddings_server.models import Model
+from text_embeddings_server.models.types import PaddedBatch, Embedding
+
+tracer = trace.get_tracer(__name__)
+
+
+def mean_pooling(model_output, attention_mask):
+    token_embeddings = model_output[0]
+    input_mask_expanded = (
+        attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+    )
+    return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(
+        input_mask_expanded.sum(1), min=1e-9
+    )
+
+
+class JinaModel(Model):
+    def __init__(self, model_path: Path, device: torch.device, dtype: torch.dtype):
+        model = AutoModel.from_pretrained(model_path, trust_remote_code=True).to(dtype).to(device)
+        self.hidden_size = model.config.hidden_size
+
+        self.has_token_type_ids = (
+                inspect.signature(model.forward).parameters.get("token_type_ids", None)
+                is not None
+        )
+
+        super(JinaModel, self).__init__(model=model, dtype=dtype, device=device)
+
+    @property
+    def batch_type(self) -> Type[PaddedBatch]:
+        return PaddedBatch
+
+    @tracer.start_as_current_span("embed")
+    def embed(self, batch: PaddedBatch) -> List[Embedding]:
+        kwargs = {"input_ids": batch.input_ids, "attention_mask": batch.attention_mask}
+        if self.has_token_type_ids:
+            kwargs["token_type_ids"] = batch.token_type_ids
+        if self.has_position_ids:
+            kwargs["position_ids"] = batch.position_ids
+
+        batch_model_output = self.model(**kwargs)
+        embeddings = mean_pooling(batch_model_output, batch.attention_mask)
+        results = torch.nn.functional.normalize(embeddings, p=2, dim=1)
+
+        cpu_results = results.view(-1).tolist()
+
+        return [
+            Embedding(
+                values=cpu_results[i * self.hidden_size: (i + 1) * self.hidden_size]
+            )
+            for i in range(len(batch))
+        ]


### PR DESCRIPTION
# What does this PR do?
This PR creates another type of model to handle Jina Models because I have observed that the way Jina models are run does not match the way they are supposed:

- [ ] They do not use `trust_remote_code` to initialize the model
- [ ] They do not use `mean_pooling` which is the way they are intended to be used.


I am open to discussions as if this should be generalized to another class not so targetted to a specific model (but some ALibiMeanPoolingModel) and also to discuss in the `get_model` method how to decide that this is going to be the model used.


* I open the PR as a draft because I still need to do testing but I would like to keep the discussion going