### PR TITLE
fix: fix inappropriate title of API docs page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
         <!-- Load the latest Swagger UI code and style from npm using unpkg.com -->
         <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
         <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css"/>
-        <title>Text Generation Inference API</title>
+        <title>Text Embeddings Inference API</title>
     </head>
     <body>
         <div id="swagger-ui"></div> <!-- Div to hold the UI component -->


### PR DESCRIPTION
Just fixes inappropriate title of API docs page.