### PR TITLE
fix: enable http feature in http-builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY Cargo.lock ./
 
 FROM builder as http-builder
 
-RUN cargo build --release --bin text-embeddings-router -F candle -F mkl-dynamic --no-default-features && sccache -s
+RUN cargo build --release --bin text-embeddings-router -F candle -F mkl-dynamic -F http --no-default-features && sccache -s
 
 FROM builder as grpc-builder
 

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -74,9 +74,9 @@ FROM builder as http-builder
 
 RUN if [ ${CUDA_COMPUTE_CAP} -ge 75 -a ${CUDA_COMPUTE_CAP} -lt 80 ]; \
     then \
-        cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F static-linking --no-default-features && sccache -s; \
+        cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F static-linking -F http --no-default-features && sccache -s; \
     else \
-        cargo build --release --bin text-embeddings-router -F candle-cuda -F static-linking --no-default-features && sccache -s; \
+        cargo build --release --bin text-embeddings-router -F candle-cuda -F static-linking -F http --no-default-features && sccache -s; \
     fi;
 
 FROM builder as grpc-builder


### PR DESCRIPTION
#90 introduced regression to non-grpc build - server fails to start and complains "You must use one of `http` or `grpc`". This is due to the http feature flag is not turned on in the Dockerfile. This PR fixes that.