### PR TITLE
Update path to match openai endpoint

### DIFF
--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -560,7 +560,7 @@ async fn embed(
 #[utoipa::path(
 post,
 tag = "Text Embeddings Inference",
-path = "/embeddings",
+path = "/v1/embeddings",
 request_body = OpenAICompatRequest,
 responses(
 (status = 200, description = "Embeddings", body = OpenAICompatResponse),
@@ -806,7 +806,7 @@ pub async fn run(
         .route("/predict", post(predict))
         .route("/rerank", post(rerank))
         // OpenAI compat route
-        .route("/embeddings", post(openai_embed))
+        .route("/v1/embeddings", post(openai_embed))
         // Base Health route
         .route("/health", get(health))
         // Inference API health route


### PR DESCRIPTION
# What does this PR do?
This PR aligns the url of the the OpenAI mock API to match the real url of the OpenAI endpoint. 

The OpenAI endpoint is located at: https://api.openai.com/v1/embeddings.

To make most drop-in replacements of the base url compatible, we will have to add `/v1` to the path.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @


@OlivierDehaene OR @Narsil

 -->
