### PR TITLE
Update Dockerfile to install curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     libomp-dev \
     ca-certificates \
     libssl-dev \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy a lot of the Intel shared objects because of the mkl_serv_intel_cpu_true patch...


### PR DESCRIPTION
# What does this PR do?

The base image doesn't have curl or wget installed, so we cannot do health checks when this is deployed as a service (for example, in AWS ECS, which is my use case).
I propose installing `curl` to be able to make container health checks like: `curl -f http://localhost:8080/health || exit 1`.

Thanks!

## Who can review?

@OlivierDehaene
