### PR TITLE
bugfix: allow for larger request payload to avoid 413 when unwarranted

### DIFF
--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use ::http::HeaderMap;
 use anyhow::Context;
-use axum::extract::Extension;
+use axum::extract::{DefaultBodyLimit, Extension};
 use axum::http::HeaderValue;
 use axum::http::{Method, StatusCode};
 use axum::routing::{get, post};
@@ -1130,6 +1130,7 @@ pub async fn run(
     };
 
     let app = app
+        .layer(DefaultBodyLimit::max(67110000))
         .layer(Extension(infer))
         .layer(Extension(info))
         .layer(Extension(prom_handle.clone()))


### PR DESCRIPTION
# What does this PR do?

This PR enlarges the allowed request payload to be 0.5GB expressed in bytes - `67110000`. 

I am submitting this PR to fix a production bug that we were facing with the service where large re-rank requests would fail due to a 413 from axum. 

@OlivierDehaene OR @Narsil
