### PR TITLE
feat: add all methods to vertex API

### DIFF
--- a/Dockerfile-cuda-all
+++ b/Dockerfile-cuda-all
@@ -33,6 +33,7 @@ FROM base-builder AS builder
 
 ARG GIT_SHA
 ARG DOCKER_LABEL
+ARG VERTEX
 
 # sccache specific variables
 ARG ACTIONS_CACHE_URL
@@ -45,7 +46,12 @@ COPY --from=planner /usr/src/recipe.json recipe.json
 
 FROM builder as builder-75
 
-RUN CUDA_COMPUTE_CAP=75 cargo chef cook --release --features candle-cuda-turing --no-default-features --recipe-path recipe.json && sccache -s
+RUN if [ $VERTEX = "true" ]; \
+    then \
+      CUDA_COMPUTE_CAP=75 cargo chef cook --release --features google --features candle-cuda-turing --no-default-features --recipe-path recipe.json && sccache -s; \
+    else \
+      CUDA_COMPUTE_CAP=75 cargo chef cook --release --features candle-cuda-turing --no-default-features --recipe-path recipe.json && sccache -s; \
+    fi;
 
 COPY backends backends
 COPY core core
@@ -53,11 +59,21 @@ COPY router router
 COPY Cargo.toml ./
 COPY Cargo.lock ./
 
-RUN CUDA_COMPUTE_CAP=75 cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F http --no-default-features && sccache -s
+RUN if [ $VERTEX = "true" ]; \
+    then \
+        CUDA_COMPUTE_CAP=75 cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F http -F google --no-default-features && sccache -s; \
+    else \
+        CUDA_COMPUTE_CAP=75 cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F http --no-default-features && sccache -s; \
+    fi;
 
 FROM builder as builder-80
 
-RUN CUDA_COMPUTE_CAP=80 cargo chef cook --release --features candle-cuda --no-default-features --recipe-path recipe.json && sccache -s
+RUN if [ $VERTEX = "true" ]; \
+    then \
+      CUDA_COMPUTE_CAP=80 cargo chef cook --release --features google --features candle-cuda-turing --no-default-features --recipe-path recipe.json && sccache -s; \
+    else \
+      CUDA_COMPUTE_CAP=80 cargo chef cook --release --features candle-cuda-turing --no-default-features --recipe-path recipe.json && sccache -s; \
+    fi;
 
 COPY backends backends
 COPY core core
@@ -65,11 +81,21 @@ COPY router router
 COPY Cargo.toml ./
 COPY Cargo.lock ./
 
-RUN CUDA_COMPUTE_CAP=80 cargo build --release --bin text-embeddings-router -F candle-cuda -F http --no-default-features && sccache -s
+RUN if [ $VERTEX = "true" ]; \
+    then \
+        CUDA_COMPUTE_CAP=80 cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F http -F google --no-default-features && sccache -s; \
+    else \
+        CUDA_COMPUTE_CAP=80 cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F http --no-default-features && sccache -s; \
+    fi;
 
 FROM builder as builder-90
 
-RUN CUDA_COMPUTE_CAP=90 cargo chef cook --release --features candle-cuda --no-default-features --recipe-path recipe.json && sccache -s
+RUN if [ $VERTEX = "true" ]; \
+    then \
+      CUDA_COMPUTE_CAP=90 cargo chef cook --release --features google --features candle-cuda-turing --no-default-features --recipe-path recipe.json && sccache -s; \
+    else \
+      CUDA_COMPUTE_CAP=90 cargo chef cook --release --features candle-cuda-turing --no-default-features --recipe-path recipe.json && sccache -s; \
+    fi;
 
 COPY backends backends
 COPY core core
@@ -77,7 +103,12 @@ COPY router router
 COPY Cargo.toml ./
 COPY Cargo.lock ./
 
-RUN CUDA_COMPUTE_CAP=90 cargo build --release --bin text-embeddings-router -F candle-cuda -F http --no-default-features && sccache -s
+RUN if [ $VERTEX = "true" ]; \
+    then \
+        CUDA_COMPUTE_CAP=90 cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F http -F google --no-default-features && sccache -s; \
+    else \
+        CUDA_COMPUTE_CAP=90 cargo build --release --bin text-embeddings-router -F candle-cuda-turing -F http --no-default-features && sccache -s; \
+    fi;
 
 FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04 as base
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -658,6 +658,87 @@
           }
         }
       }
+    },
+    "/vertex": {
+      "post": {
+        "tags": [
+          "Text Embeddings Inference"
+        ],
+        "summary": "Generate embeddings from a Vertex request",
+        "description": "Generate embeddings from a Vertex request",
+        "operationId": "vertex_compatibility",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VertexRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Results"
+          },
+          "413": {
+            "description": "Batch size error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": "Batch size error",
+                  "error_type": "validation"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Tokenization error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": "Tokenization error",
+                  "error_type": "tokenizer"
+                }
+              }
+            }
+          },
+          "424": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": "Inference failed",
+                  "error_type": "backend"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Model is overloaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "error": "Model is overloaded",
+                  "error_type": "overloaded"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1338,6 +1419,274 @@
             }
           ]
         ]
+      },
+      "VertexInstance": {
+        "oneOf": [
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EmbedRequest"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "embed"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EmbedAllRequest"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "embed_all"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EmbedSparseRequest"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "embed_sparse"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PredictRequest"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "predict"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RerankRequest"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "rerank"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TokenizeRequest"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "tokenize"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "VertexRequest": {
+        "type": "object",
+        "required": [
+          "instances"
+        ],
+        "properties": {
+          "instances": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VertexInstance"
+            }
+          }
+        }
+      },
+      "VertexResponse": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/VertexResponseInstance"
+        }
+      },
+      "VertexResponseInstance": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/EmbedResponse"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "embed"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/EmbedAllResponse"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "embed_all"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/EmbedSparseResponse"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "embed_sparse"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/PredictResponse"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "predict"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/RerankResponse"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "rerank"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "type",
+              "result"
+            ],
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/TokenizeResponse"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "tokenize"
+                ]
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
+        }
       }
     }
   },

--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -20,8 +20,8 @@ use axum::routing::{get, post};
 use axum::{http, Json, Router};
 use axum_tracing_opentelemetry::middleware::OtelAxumLayer;
 use futures::future::join_all;
-use http::header::AUTHORIZATION;
 use futures::FutureExt;
+use http::header::AUTHORIZATION;
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
@@ -1384,20 +1384,6 @@ pub async fn run(
         .route("/ping", get(health))
         // Prometheus metrics route
         .route("/metrics", get(metrics));
-
-    #[cfg(feature = "google")]
-    {
-        tracing::info!("Built with `google` feature");
-        tracing::info!(
-            "Environment variables `AIP_PREDICT_ROUTE` and `AIP_HEALTH_ROUTE` will be respected."
-        );
-        if let Ok(env_predict_route) = std::env::var("AIP_PREDICT_ROUTE") {
-            app = app.route(&env_predict_route, post(vertex_compatibility));
-        }
-        if let Ok(env_health_route) = std::env::var("AIP_HEALTH_ROUTE") {
-            app = app.route(&env_health_route, get(health));
-        }
-    let mut app = Router::new().merge(base_routes);
 
     #[cfg(feature = "google")]
     {

--- a/router/src/http/types.rs
+++ b/router/src/http/types.rs
@@ -383,31 +383,20 @@ pub(crate) struct SimpleToken {
 pub(crate) struct TokenizeResponse(pub Vec<Vec<SimpleToken>>);
 
 #[derive(Deserialize, ToSchema)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub(crate) enum VertexInstance {
-    Embed(EmbedRequest),
-    EmbedAll(EmbedAllRequest),
-    EmbedSparse(EmbedSparseRequest),
-    Predict(PredictRequest),
-    Rerank(RerankRequest),
-    Tokenize(TokenizeRequest),
-}
-
-#[derive(Deserialize, ToSchema)]
 pub(crate) struct VertexRequest {
-    pub instances: Vec<VertexInstance>,
+    pub instances: Vec<serde_json::Value>,
 }
 
 #[derive(Serialize, ToSchema)]
-#[serde(tag = "type", content = "result", rename_all = "snake_case")]
+#[serde(untagged)]
 pub(crate) enum VertexResponseInstance {
     Embed(EmbedResponse),
-    EmbedAll(EmbedAllResponse),
     EmbedSparse(EmbedSparseResponse),
     Predict(PredictResponse),
     Rerank(RerankResponse),
-    Tokenize(TokenizeResponse),
 }
 
 #[derive(Serialize, ToSchema)]
-pub(crate) struct VertexResponse(pub Vec<VertexResponseInstance>);
+pub(crate) struct VertexResponse {
+    pub predictions: Vec<VertexResponseInstance>,
+}

--- a/router/src/http/types.rs
+++ b/router/src/http/types.rs
@@ -382,19 +382,32 @@ pub(crate) struct SimpleToken {
 #[schema(example = json!([[{"id": 0, "text": "test", "special": false, "start": 0, "stop": 2}]]))]
 pub(crate) struct TokenizeResponse(pub Vec<Vec<SimpleToken>>);
 
-#[derive(Clone, Deserialize, ToSchema)]
-pub(crate) struct VertexInstance {
-    #[schema(example = "What is Deep Learning?")]
-    pub inputs: String,
-    #[serde(default)]
-    #[schema(default = "false", example = "false")]
-    pub truncate: bool,
-    #[serde(default = "default_normalize")]
-    #[schema(default = "true", example = "true")]
-    pub normalize: bool,
+#[derive(Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum VertexInstance {
+    Embed(EmbedRequest),
+    EmbedAll(EmbedAllRequest),
+    EmbedSparse(EmbedSparseRequest),
+    Predict(PredictRequest),
+    Rerank(RerankRequest),
+    Tokenize(TokenizeRequest),
 }
 
 #[derive(Deserialize, ToSchema)]
 pub(crate) struct VertexRequest {
     pub instances: Vec<VertexInstance>,
 }
+
+#[derive(Serialize, ToSchema)]
+#[serde(tag = "type", content = "result", rename_all = "snake_case")]
+pub(crate) enum VertexResponseInstance {
+    Embed(EmbedResponse),
+    EmbedAll(EmbedAllResponse),
+    EmbedSparse(EmbedSparseResponse),
+    Predict(PredictResponse),
+    Rerank(RerankResponse),
+    Tokenize(TokenizeResponse),
+}
+
+#[derive(Serialize, ToSchema)]
+pub(crate) struct VertexResponse(pub Vec<VertexResponseInstance>);

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -246,7 +246,7 @@ pub async fn run(
         std::env::var("AIP_HTTP_PORT")
             .ok()
             .and_then(|p| p.parse().ok())
-            .expect("Invalid or unset AIP_HTTP_PORT")
+            .context("Invalid or unset AIP_HTTP_PORT")?
     } else {
         port
     };

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -246,7 +246,7 @@ pub async fn run(
         std::env::var("AIP_HTTP_PORT")
             .ok()
             .and_then(|p| p.parse().ok())
-            .context("Invalid or unset AIP_HTTP_PORT")?
+            .context("`AIP_HTTP_PORT` env var must be set for Google Vertex deployments")?
     } else {
         port
     };
@@ -263,6 +263,9 @@ pub async fn run(
 
     #[cfg(all(feature = "grpc", feature = "http"))]
     compile_error!("Features `http` and `grpc` cannot be enabled at the same time.");
+
+    #[cfg(all(feature = "grpc", feature = "google"))]
+    compile_error!("Features `http` and `google` cannot be enabled at the same time.");
 
     #[cfg(not(any(feature = "http", feature = "grpc")))]
     compile_error!("Either feature `http` or `grpc` must be enabled.");

--- a/router/tests/common.rs
+++ b/router/tests/common.rs
@@ -60,6 +60,8 @@ pub async fn start_server(model_id: String, revision: Option<String>, dtype: DTy
             8090,
             None,
             None,
+            2_000_000,
+            None,
             None,
             None,
         )


### PR DESCRIPTION
@drbh what do you think?

@philschmid FYI this will modify the API to:

```
curl 127.0.0.1:3000/vertex \
    -X POST \
    -d '{"instances": [{"type": "embed", "inputs": "I like you."}]}' \
    -H 'Content-Type: application/json'
    
 # [{"type":"embed","result":[[-0.057003036,-0.022593308, ...]] }]
```