### PR TITLE
Add optional CORS allow any option value in http server cli

### DIFF
--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -1410,11 +1410,15 @@ pub async fn run(
     // map to go inside the option and then map to parse from String to HeaderValue
     // Finally, convert to AllowOrigin
     let allow_origin: Option<AllowOrigin> = cors_allow_origin.map(|cors_allow_origin| {
-        AllowOrigin::list(
-            cors_allow_origin
-                .into_iter()
-                .map(|origin| origin.parse::<HeaderValue>().unwrap()),
-        )
+        if cors_allow_origin.iter().any(|origin| origin == "*") {
+            AllowOrigin::any()
+        } else {
+            AllowOrigin::list(
+                cors_allow_origin
+                    .into_iter()
+                    .map(|origin| origin.parse::<HeaderValue>().unwrap()),
+            )
+        }
     });
 
     let prom_handle = prom_builder


### PR DESCRIPTION
This PR adds option value '*' to --cors-allow-origin cli option to allow browser-based apps to use the embedding server directly. This is useful for local deployments of the embeddings inference server.