### PR TITLE
tokenizer max limit on input size

### DIFF
--- a/core/src/tokenization.rs
+++ b/core/src/tokenization.rs
@@ -272,6 +272,7 @@ fn prepare_pre_prompt(
     Ok(pre_prompt)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn tokenize_input(
     inputs: EncodingInput,
     add_special_tokens: bool,

--- a/core/src/tokenization.rs
+++ b/core/src/tokenization.rs
@@ -284,13 +284,11 @@ fn tokenize_input(
 ) -> Result<(Option<String>, RawEncoding), TextEmbeddingsError> {
     let pre_prompt = prepare_pre_prompt(default_prompt, prompt_name, prompts)?;
 
-    if inputs.count_chars() > max_input_length * MAX_CHAR_MULTIPLIER {
+    let input_chars = inputs.count_chars();
+    let limit = max_input_length * MAX_CHAR_MULTIPLIER;
+    if input_chars > limit {
         return Err(TextEmbeddingsError::Validation(format!(
-            "`inputs` cannot be larger than max_input_length * {}, in this case {} * {} = {}",
-            MAX_CHAR_MULTIPLIER,
-            max_input_length,
-            MAX_CHAR_MULTIPLIER,
-            max_input_length * MAX_CHAR_MULTIPLIER
+            "`inputs` must have less than {limit} characters. Given: {input_chars}"
         )));
     }
 

--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -1233,7 +1233,6 @@ async fn tokenize(
         Ok::<Vec<SimpleToken>, ErrorResponse>(tokens)
     };
 
-    
     let tokens = match req.inputs {
         TokenizeInput::Single(input) => {
             vec![tokenize_inner(input, req.add_special_tokens, req.prompt_name, infer.0).await?]

--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -39,8 +39,6 @@ use tracing::instrument;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-static MAX_CHAR_MULTIPLIER: usize = 250;
-
 ///Text Embeddings Inference endpoint info
 #[utoipa::path(
 get,
@@ -1238,36 +1236,11 @@ async fn tokenize(
     
     let tokens = match req.inputs {
         TokenizeInput::Single(input) => {
-
-            if input.chars().count() > info.max_input_length * MAX_CHAR_MULTIPLIER {
-                let message = format!("`inputs` cannot be larger than max_input_length * {}, in this case {} * {} = {}", MAX_CHAR_MULTIPLIER, info.max_input_length, MAX_CHAR_MULTIPLIER, info.max_input_length * MAX_CHAR_MULTIPLIER);
-                tracing::error!("{message}");
-                let err = ErrorResponse {
-                    error: message,
-                    error_type: ErrorType::Validation,
-                };
-                let counter = metrics::counter!("te_request_failure", "err" => "validation");
-                counter.increment(1);
-                Err(err)?;
-            }
-
             vec![tokenize_inner(input, req.add_special_tokens, req.prompt_name, infer.0).await?]
         }
         TokenizeInput::Batch(inputs) => {
             if inputs.is_empty() {
                 let message = "`inputs` cannot be empty".to_string();
-                tracing::error!("{message}");
-                let err = ErrorResponse {
-                    error: message,
-                    error_type: ErrorType::Validation,
-                };
-                let counter = metrics::counter!("te_request_failure", "err" => "validation");
-                counter.increment(1);
-                Err(err)?;
-            }
-            
-            if inputs.iter().any(|s| s.chars().count() > info.max_input_length * MAX_CHAR_MULTIPLIER) {
-                let message = format!("`inputs` cannot be larger than max_input_length * {}, in this case {} * {} = {}", MAX_CHAR_MULTIPLIER, info.max_input_length, MAX_CHAR_MULTIPLIER, info.max_input_length * MAX_CHAR_MULTIPLIER);
                 tracing::error!("{message}");
                 let err = ErrorResponse {
                     error: message,


### PR DESCRIPTION
# What does this PR do?

- Fixed issue #235  
- adds an upper limit for how large the input can be, a constant (250) * `max_input_length`
