### PR TITLE
Rename 'Sentence Transformers' to 'sentence-transformers' in docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Options:
       --default-prompt-name <DEFAULT_PROMPT_NAME>
           The name of the prompt that should be used by default for encoding. If not set, no prompt will be applied.
 
-          Must be a key in the `Sentence Transformers` configuration `prompts` dictionary.
+          Must be a key in the `sentence-transformers` configuration `prompts` dictionary.
 
           For example if ``default_prompt_name`` is "query" and the ``prompts`` is {"query": "query: ", ...}, then the
           sentence "What is the capital of France?" will be encoded as "query: What is the capital of France?" because

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -851,7 +851,7 @@
           },
           "prompt_name": {
             "type": "string",
-            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `Sentence Transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
+            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `sentence-transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
             "default": "null",
             "example": "null",
             "nullable": true
@@ -910,7 +910,7 @@
           },
           "prompt_name": {
             "type": "string",
-            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `Sentence Transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
+            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `sentence-transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
             "default": "null",
             "example": "null",
             "nullable": true
@@ -959,7 +959,7 @@
           },
           "prompt_name": {
             "type": "string",
-            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `Sentence Transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
+            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `sentence-transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
             "default": "null",
             "example": "null",
             "nullable": true
@@ -1560,7 +1560,7 @@
         "properties": {
           "prompt_name": {
             "type": "string",
-            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `Sentence Transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
+            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `sentence-transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
             "default": "null",
             "example": "null",
             "nullable": true
@@ -1695,7 +1695,7 @@
           },
           "prompt_name": {
             "type": "string",
-            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `Sentence Transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
+            "description": "The name of the prompt that should be used by for encoding. If not set, no prompt\nwill be applied.\n\nMust be a key in the `sentence-transformers` configuration `prompts` dictionary.\n\nFor example if ``prompt_name`` is \"query\" and the ``prompts`` is {\"query\": \"query: \", ...},\nthen the sentence \"What is the capital of France?\" will be encoded as\n\"query: What is the capital of France?\" because the prompt text will be prepended before\nany text to encode.",
             "default": "null",
             "example": "null",
             "nullable": true

--- a/docs/source/en/cli_arguments.md
+++ b/docs/source/en/cli_arguments.md
@@ -110,7 +110,7 @@ Options:
       --default-prompt-name <DEFAULT_PROMPT_NAME>
           The name of the prompt that should be used by default for encoding. If not set, no prompt will be applied.
 
-          Must be a key in the `Sentence Transformers` configuration `prompts` dictionary.
+          Must be a key in the `sentence-transformers` configuration `prompts` dictionary.
 
           For example if ``default_prompt_name`` is "query" and the ``prompts`` is {"query": "query: ", ...}, then the
           sentence "What is the capital of France?" will be encoded as "query: What is the capital of France?" because

--- a/router/src/http/types.rs
+++ b/router/src/http/types.rs
@@ -380,7 +380,7 @@ pub(crate) struct SimilarityParameters {
     /// The name of the prompt that should be used by for encoding. If not set, no prompt
     /// will be applied.
     ///
-    /// Must be a key in the `Sentence Transformers` configuration `prompts` dictionary.
+    /// Must be a key in the `sentence-transformers` configuration `prompts` dictionary.
     ///
     /// For example if ``prompt_name`` is "query" and the ``prompts`` is {"query": "query: ", ...},
     /// then the sentence "What is the capital of France?" will be encoded as
@@ -414,7 +414,7 @@ pub(crate) struct EmbedRequest {
     /// The name of the prompt that should be used by for encoding. If not set, no prompt
     /// will be applied.
     ///
-    /// Must be a key in the `Sentence Transformers` configuration `prompts` dictionary.
+    /// Must be a key in the `sentence-transformers` configuration `prompts` dictionary.
     ///
     /// For example if ``prompt_name`` is "query" and the ``prompts`` is {"query": "query: ", ...},
     /// then the sentence "What is the capital of France?" will be encoded as
@@ -447,7 +447,7 @@ pub(crate) struct EmbedSparseRequest {
     /// The name of the prompt that should be used by for encoding. If not set, no prompt
     /// will be applied.
     ///
-    /// Must be a key in the `Sentence Transformers` configuration `prompts` dictionary.
+    /// Must be a key in the `sentence-transformers` configuration `prompts` dictionary.
     ///
     /// For example if ``prompt_name`` is "query" and the ``prompts`` is {"query": "query: ", ...},
     /// then the sentence "What is the capital of France?" will be encoded as
@@ -478,7 +478,7 @@ pub(crate) struct EmbedAllRequest {
     /// The name of the prompt that should be used by for encoding. If not set, no prompt
     /// will be applied.
     ///
-    /// Must be a key in the `Sentence Transformers` configuration `prompts` dictionary.
+    /// Must be a key in the `sentence-transformers` configuration `prompts` dictionary.
     ///
     /// For example if ``prompt_name`` is "query" and the ``prompts`` is {"query": "query: ", ...},
     /// then the sentence "What is the capital of France?" will be encoded as
@@ -516,7 +516,7 @@ pub(crate) struct TokenizeRequest {
     /// The name of the prompt that should be used by for encoding. If not set, no prompt
     /// will be applied.
     ///
-    /// Must be a key in the `Sentence Transformers` configuration `prompts` dictionary.
+    /// Must be a key in the `sentence-transformers` configuration `prompts` dictionary.
     ///
     /// For example if ``prompt_name`` is "query" and the ``prompts`` is {"query": "query: ", ...},
     /// then the sentence "What is the capital of France?" will be encoded as

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -82,7 +82,7 @@ struct Args {
     /// The name of the prompt that should be used by default for encoding. If not set, no prompt
     /// will be applied.
     ///
-    /// Must be a key in the `Sentence Transformers` configuration `prompts` dictionary.
+    /// Must be a key in the `sentence-transformers` configuration `prompts` dictionary.
     ///
     /// For example if ``default_prompt_name`` is "query" and the ``prompts`` is {"query": "query: ", ...},
     /// then the sentence "What is the capital of France?" will be encoded as


### PR DESCRIPTION
Based on @osanseviero 's suggestion in https://github.com/huggingface/huggingface.js/pull/781#discussion_r1675577154