### PR TITLE
add missing link to TEI Gaudi in docs

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -13,6 +13,8 @@
     title: Using TEI locally with Metal
   - local: local_gpu
     title: Using TEI locally with GPU
+  - local: local_gaudi
+    title: Using TEI locally with Intel Gaudi 
   - local: private_models
     title: Serving private and gated models
 #  - local: tei_cli

--- a/docs/source/en/local_gaudi.md
+++ b/docs/source/en/local_gaudi.md
@@ -1,0 +1,19 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Using TEI locally with Intel Gaudi
+
+Check out this [repository](https://github.com/huggingface/tei-gaudi) to serve models with TEI on Gaudi and Gaudi 2 with [Optimum Habana] (https://huggingface.co/docs/optimum/habana/index)


### PR DESCRIPTION
Added link to TEI gaudi in docs. 

I followed same approach as in TGI documentation: https://huggingface.co/docs/text-generation-inference/index 