### PR TITLE
fix: add serde default for truncation direction

### DIFF
--- a/router/src/http/types.rs
+++ b/router/src/http/types.rs
@@ -375,6 +375,7 @@ pub(crate) struct SimilarityInput {
 pub(crate) struct SimilarityParameters {
     #[schema(default = "false", example = "false", nullable = true)]
     pub truncate: Option<bool>,
+    #[serde(default)]
     #[schema(default = "right", example = "right")]
     pub truncation_direction: TruncationDirection,
     /// The name of the prompt that should be used by for encoding. If not set, no prompt


### PR DESCRIPTION
This PR adjusts the similarity parameters to use a default for truncation direction 


example request
```bash
curl "http://localhost:3000/similarity" \
-X POST \
-H "Accept: application/json" \
-H "Authorization: Bearer hf_XXXXX" \
-H "Content-Type: application/json" \
-d '{
    "inputs": {
        "sentences": [
            "That is a happy dog",
            "That is a very happy person",
            "Today is a sunny day"
        ],
        "source_sentence": "That is a happy person"
    },
    "parameters": {}
}'
# [0.85468096,0.9658465,0.68776166]
```