### PR TITLE
Pin `cargo-chef` installation to 0.1.62

### DIFF
--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -3,6 +3,8 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 AS base-builder
 ENV SCCACHE=0.5.4
 ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 ENV PATH="/root/.cargo/bin:${PATH}"
+# aligned with `cargo-chef` version in `lukemathwalker/cargo-chef:latest-rust-1.75-bookworm` 
+ENV CARGO_CHEF=0.1.62
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
@@ -15,7 +17,7 @@ RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v$SCCACHE/sc
     chmod +x /usr/local/bin/sccache
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef --version $CARGO_CHEF --locked
 
 FROM base-builder AS planner
 

--- a/Dockerfile-cuda-all
+++ b/Dockerfile-cuda-all
@@ -3,6 +3,8 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04 AS base-builder
 ENV SCCACHE=0.5.4
 ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 ENV PATH="/root/.cargo/bin:${PATH}"
+# aligned with `cargo-chef` version in `lukemathwalker/cargo-chef:latest-rust-1.75-bookworm` 
+ENV CARGO_CHEF=0.1.62
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
@@ -15,7 +17,7 @@ RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v$SCCACHE/sc
     chmod +x /usr/local/bin/sccache
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-RUN cargo install cargo-chef --locked
+RUN cargo install cargo-chef --version $CARGO_CHEF --locked
 
 FROM base-builder AS planner
 


### PR DESCRIPTION
# What does this PR do?

This PR pins the `cargo-chef` version installed on both `Dockerfile-cuda` and `Dockerfile-cuda-all`, since it's not pinned and so on installing the `latest`. Installing the latest was working up until [`cargo-chef` 0.1.68](https://github.com/LukeMathWalker/cargo-chef/releases/tag/v0.1.68), but fails on 0.1.69 and greater as per the following logs:

```
ubuntu:~/text-embeddings-inference$ docker build -f Dockerfile-cuda .
[+] Building 2.1s (22/29)                                                                                                                                                                                                                    docker:default
 => [internal] load build definition from Dockerfile-cuda                                                                                                                                                                                              0.0s
 => => transferring dockerfile: 4.63kB                                                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:12.2.0-base-ubuntu22.04                                                                                                                                                                         0.1s
 => [internal] load metadata for docker.io/nvidia/cuda:12.2.0-devel-ubuntu22.04                                                                                                                                                                        0.1s
 => [internal] load .dockerignore                                                                                                                                                                                                                      0.0s
 => => transferring context: 53B                                                                                                                                                                                                                       0.0s
 => [internal] load build context                                                                                                                                                                                                                      0.1s
 => => transferring context: 2.74MB                                                                                                                                                                                                                    0.0s
 => CACHED [base 1/2] FROM docker.io/nvidia/cuda:12.2.0-base-ubuntu22.04@sha256:ecdf8549dd5f12609e365217a64dedde26ecda26da8f3ff3f82def6749f53051                                                                                                       0.0s
 => [base-builder 1/5] FROM docker.io/nvidia/cuda:12.2.0-devel-ubuntu22.04@sha256:c4e81887e4aa9f13b1119337323cba89601319ecb282383b879c4ba50510fd17                                                                                                     0.0s
 => CACHED [base-builder 2/5] RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends     curl     libssl-dev     pkg-config     && rm -rf /var/lib/apt/lists/*                                                0.0s
 => CACHED [base-builder 3/5] RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | tar -xzv --strip-components=1 -C /usr/local/bin sccache-v0.5.4-x86_64-unknown-linux-musl/s  0.0s
 => CACHED [base-builder 4/5] RUN curl https://sh.rustup.rs -sSf | bash -s -- -y                                                                                                                                                                       0.0s
 => CACHED [base-builder 5/5] RUN cargo install cargo-chef --locked                                                                                                                                                                                    0.0s
 => CACHED [planner 1/7] WORKDIR /usr/src                                                                                                                                                                                                              0.0s
 => CANCELED [base 2/2] RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends     ca-certificates     libssl-dev     curl     && rm -rf /var/lib/apt/lists/*                                                 1.9s
 => [builder 2/9] RUN if [ 80 -ge 75 -a 80 -lt 80 ];     then          nvprune --generate-code code=sm_80 /usr/local/cuda/lib64/libcublas_static.a -o /usr/local/cuda/lib64/libcublas_static.a;     elif [ 80 -ge 80 -a 80 -lt 90 ];     then          1.2s
 => [planner 2/7] COPY backends backends                                                                                                                                                                                                               0.1s
 => [planner 3/7] COPY core core                                                                                                                                                                                                                       0.0s
 => [planner 4/7] COPY router router                                                                                                                                                                                                                   0.1s
 => [planner 5/7] COPY Cargo.toml ./                                                                                                                                                                                                                   0.0s
 => [planner 6/7] COPY Cargo.lock ./                                                                                                                                                                                                                   0.0s
 => [planner 7/7] RUN cargo chef prepare  --recipe-path recipe.json                                                                                                                                                                                    0.8s
 => [builder 3/9] COPY --from=planner /usr/src/recipe.json recipe.json                                                                                                                                                                                 0.1s
 => ERROR [builder 4/9] RUN if [ 80 -ge 75 -a 80 -lt 80 ];     then         cargo chef cook --release --features candle-cuda-turing --features static-linking --no-default-features --recipe-path recipe.json && sccache -s;     else         cargo c  0.5s
------                                                                                                                                                                                                                                                      
 > [builder 4/9] RUN if [ 80 -ge 75 -a 80 -lt 80 ];     then         cargo chef cook --release --features candle-cuda-turing --features static-linking --no-default-features --recipe-path recipe.json && sccache -s;     else         cargo chef cook --release --features candle-cuda --features static-linking --no-default-features --recipe-path recipe.json && sccache -s;     fi;:                                                                                                                               
0.294 warning: /usr/src/router/Cargo.toml: unused manifest key: bin.0.plugin                                                                                                                                                                                
0.294 warning: /usr/src/router/Cargo.toml: unused manifest key: lib.plugin                                                                                                                                                                                  
0.294 warning: /usr/src/router/Cargo.toml: unused manifest key: test.0.plugin                                                                                                                                                                               
0.294 warning: /usr/src/router/Cargo.toml: unused manifest key: test.1.plugin                                                                                                                                                                               
0.294 warning: /usr/src/router/Cargo.toml: unused manifest key: test.2.plugin                                                                                                                                                                               
0.294 warning: /usr/src/router/Cargo.toml: unused manifest key: test.3.plugin                                                                                                                                                                               
0.294 error: failed to parse manifest at `/usr/src/router/Cargo.toml`                                                                                                                                                                                       
0.294                                                                                                                                                                                                                                                       
0.294 Caused by:                                                                                                                                                                                                                                            
0.294   the target `text-embeddings-router` is a binary and can't have any crate-types set (currently "bin")
0.296 thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-chef-0.1.69/src/recipe.rs:218:27:
0.296 Exited with status code: 101
0.296 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
------

 1 warning found (use docker --debug to expand):
 - SecretsUsedInArgOrEnv: Do not use ARG or ENV instructions for sensitive data (ARG "ACTIONS_RUNTIME_TOKEN") (line 45)
Dockerfile-cuda:65
--------------------
  64 |     
  65 | >>> RUN if [ ${CUDA_COMPUTE_CAP} -ge 75 -a ${CUDA_COMPUTE_CAP} -lt 80 ]; \
  66 | >>>     then \
  67 | >>>         cargo chef cook --release --features candle-cuda-turing --features static-linking --no-default-features --recipe-path recipe.json && sccache -s; \
  68 | >>>     else \
  69 | >>>         cargo chef cook --release --features candle-cuda --features static-linking --no-default-features --recipe-path recipe.json && sccache -s; \
  70 | >>>     fi;
  71 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c if [ ${CUDA_COMPUTE_CAP} -ge 75 -a ${CUDA_COMPUTE_CAP} -lt 80 ];     then         cargo chef cook --release --features candle-cuda-turing --features static-linking --no-default-features --recipe-path recipe.json && sccache -s;     else         cargo chef cook --release --features candle-cuda --features static-linking --no-default-features --recipe-path recipe.json && sccache -s;     fi;" did not complete successfully: exit code: 101
```

To reproduce you can clone the `text-embeddings-inference` repository and run `docker build -f Dockerfile-cuda .`, and the error will show; but when pinning `cargo-chef` to either the same version as `lukemathwalker/cargo-chef:latest-rust-1.75-bookworm` or 0.1.68, it will work.

See below the `cargo-chef` installed version on `lukemathwalker/cargo-chef:latest-rust-1.75-bookworm`:

```
ubuntu:~/text-embeddings-inference$ docker run lukemathwalker/cargo-chef:latest-rust-1.75-bookworm cargo chef --version
Unable to find image 'lukemathwalker/cargo-chef:latest-rust-1.75-bookworm' locally
latest-rust-1.75-bookworm: Pulling from lukemathwalker/cargo-chef
66932e2b787d: Pull complete 
4afa7e263db1: Pull complete 
c812910e5e62: Pull complete 
f4e4299bb649: Pull complete 
53b4298a0bf1: Pull complete 
43967d52f2c9: Pull complete 
Digest: sha256:de118eaad2ecaf38abb661ecf6f06230cccf862db655670e873bc180e2d55fa6
Status: Downloaded newer image for lukemathwalker/cargo-chef:latest-rust-1.75-bookworm
cargo-chef-chef 0.1.62
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@OlivierDehaene OR @Narsil
