### PR TITLE
feat: support HF_ENDPOINT environment when downloading model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -1607,11 +1607,9 @@ checksum = "cc03dcb0b0a83ae3f3363ec811014ae669f083e4e499c66602f447c4828737a1"
 dependencies = [
  "dirs",
  "futures",
- "http 1.3.1",
  "indicatif",
  "libc",
  "log",
- "native-tls",
  "num_cpus",
  "rand 0.8.5",
  "reqwest",
@@ -1619,7 +1617,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "ureq",
  "windows-sys 0.59.0",
 ]
 
@@ -2100,15 +2097,6 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -3220,8 +3208,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
- "itertools 0.12.1",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap 0.10.0",
  "once_cell",
@@ -3254,7 +3242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -5024,7 +5012,6 @@ dependencies = [
  "base64 0.22.1",
  "flate2",
  "log",
- "native-tls",
  "once_cell",
  "rustls",
  "rustls-pki-types",

--- a/backends/candle/Cargo.toml
+++ b/backends/candle/Cargo.toml
@@ -29,7 +29,7 @@ memmap2 = "^0.9"
 [dev-dependencies]
 insta = { git = "https://github.com/OlivierDehaene/insta", rev = "f4f98c0410b91fb5a28b10df98e4422955be9c2c", features = ["yaml"] }
 is_close = "0.1.3"
-hf-hub = "0.4.2"
+hf-hub = { workspace = true }
 anyhow = { workspace = true }
 tokenizers = { workspace = true }
 serial_test = { workspace = true }

--- a/backends/candle/tests/common.rs
+++ b/backends/candle/tests/common.rs
@@ -107,7 +107,7 @@ pub fn download_artifacts(
     model_id: &'static str,
     revision: Option<&'static str>,
 ) -> Result<PathBuf> {
-    let mut builder = ApiBuilder::new().with_progress(false);
+    let mut builder = ApiBuilder::from_env().with_progress(false);
 
     if let Some(cache_dir) = std::env::var_os("HUGGINGFACE_HUB_CACHE") {
         builder = builder.with_cache_dir(cache_dir.into());

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -70,7 +70,9 @@ pub async fn run(
         // Using a local model
         (model_id_path.to_path_buf(), None)
     } else {
-        let mut builder = ApiBuilder::new().with_progress(false).with_token(hf_token);
+        let mut builder = ApiBuilder::from_env()
+            .with_progress(false)
+            .with_token(hf_api_token);
 
         if let Some(cache_dir) = huggingface_hub_cache {
             builder = builder.with_cache_dir(cache_dir.into());


### PR DESCRIPTION
# What does this PR do?

Hey! Big thanks for this awesome project. But because of network problems, I've been manually downloading models and mounting them. It's a real pain, especially when I want to try out new models. So, I thought I'd make some changes to make things easier for users like me.

This PR bumps up the `hf-hub` version ([release note](https://github.com/huggingface/hf-hub/releases/tag/v0.4.0)) and tweaks the related code to support using the `HF_ENDPOINT` environment variable. This way, we can use mirrors for downloading, which should speed things up and make it more reliable, especially in bad network env.

By the way, fix #416

Maybe the documentation should also be updated, but I'm not sure if my changes are appropriate to go on...

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Could you help review this PR when you're available?

@OlivierDehaene @Narsil

