### PR TITLE
Add intel based images to the CI

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -60,5 +60,32 @@
     "sccache": true,
     "grpc": true,
     "dockerfile": "Dockerfile"
+  },
+  {
+    "name": "cpu-ipex",
+    "imageNamePrefix": "cpu-ipex",
+    "runOn": "always",
+    "sccache": true,
+    "extraBuildArgs": "PLATFORM=cpu",
+    "grpc": true,
+    "dockerfile": "Dockerfile-intel"
+  },
+  {
+    "name": "xpu-ipex",
+    "imageNamePrefix": "xpu-ipex",
+    "runOn": "always",
+    "sccache": true,
+    "extraBuildArgs": "PLATFORM=xpu",
+    "grpc": true,
+    "dockerfile": "Dockerfile-intel"
+  },
+  {
+    "name": "hpu",
+    "imageNamePrefix": "hpu",
+    "runOn": "always",
+    "sccache": true,
+    "extraBuildArgs": "PLATFORM=hpu",
+    "grpc": true,
+    "dockerfile": "Dockerfile-intel"
   }
 ]


### PR DESCRIPTION
# What does this PR do?

This PR add Intel based images to the CI

The new images will be available at
```
ghcr.io/huggingface/text-embeddings-inference:cpu-ipex-sha-<SHA_COMMIT>
ghcr.io/huggingface/text-embeddings-inference:xpu-ipex-sha-<SHA_COMMIT>
ghcr.io/huggingface/text-embeddings-inference:hpu-sha-<SHA_COMMIT>
```
