### PR TITLE
Fix typo on intel docker image

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -63,7 +63,7 @@
   },
   {
     "name": "cpu-ipex",
-    "imageNamePrefix": "cpu-ipex",
+    "imageNamePrefix": "cpu-ipex-",
     "runOn": "always",
     "sccache": true,
     "extraBuildArgs": "PLATFORM=cpu",
@@ -72,7 +72,7 @@
   },
   {
     "name": "xpu-ipex",
-    "imageNamePrefix": "xpu-ipex",
+    "imageNamePrefix": "xpu-ipex-",
     "runOn": "always",
     "sccache": true,
     "extraBuildArgs": "PLATFORM=xpu",
@@ -81,7 +81,7 @@
   },
   {
     "name": "hpu",
-    "imageNamePrefix": "hpu",
+    "imageNamePrefix": "hpu-",
     "runOn": "always",
     "sccache": true,
     "extraBuildArgs": "PLATFORM=hpu",


### PR DESCRIPTION
# What does this PR do?

The intel image are currently built as `ghcr.io/huggingface/text-embeddings-inference:hpulatest` instead of `ghcr.io/huggingface/text-embeddings-inference:hpu-latest`

There is a typo in the previous request #518