### PR TITLE
Fix `FromAsCasing` warning in `Dockerfile-intel`

### DIFF
--- a/Dockerfile-intel
+++ b/Dockerfile-intel
@@ -44,13 +44,13 @@ RUN PROTOC_ZIP=protoc-21.12-linux-x86_64.zip && \
     unzip -o $PROTOC_ZIP -d /usr/local 'include/*' && \
     rm -f $PROTOC_ZIP
 
-FROM builder as http-builder
+FROM builder AS http-builder
 
 RUN --mount=type=secret,id=actions_cache_url,env=ACTIONS_CACHE_URL \
     --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
     cargo build --release --bin text-embeddings-router -F python -F http --no-default-features && sccache -s
 
-FROM builder as grpc-builder
+FROM builder AS grpc-builder
 
 COPY proto proto
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes the `FromAsCasing` warning on `Dockerfile-intel` so as to go from `FROM ... as ...` into `FROM ... AS ...` which is the standard. This PR doesn't solve anything critical, but rather annoying (see screenshot below).

![image](https://github.com/user-attachments/assets/55235cf5-532c-4635-a1fe-80a0fc9256c2)

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@Narsil or @baptistecolle