### PR TITLE
Make `sliding_window` for `Qwen2` optional

### DIFF
--- a/backends/candle/src/models/flash_qwen2.rs
+++ b/backends/candle/src/models/flash_qwen2.rs
@@ -21,8 +21,8 @@ struct Qwen2Attention {
 
 impl Qwen2Attention {
     pub fn load(vb: VarBuilder, config: &Qwen2Config) -> Result<Self> {
-        if config.sliding_window.is_some() {
-            candle::bail!("Sliding window is not supported for Qwen2");
+        if config.use_sliding_window {
+            candle::bail!("Sliding window is not supported for Qwen2",);
         }
 
         let num_attention_heads = config.num_attention_heads;

--- a/backends/candle/src/models/flash_qwen2.rs
+++ b/backends/candle/src/models/flash_qwen2.rs
@@ -264,7 +264,15 @@ impl FlashQwen2Model {
             ModelType::Embedding(pool) => pool,
         };
 
-        let vb = vb.pp("model");
+        // Pushing the prefix for `model` is apparently only required if the model architecture is
+        // ForCausalLM as it contains the `lm_head`, other than that, the `model` key won't be
+        // present e.g. a model without the `model` key as it's a `Qwen2Model` instance not a
+        // `Qwen2ModelForCausalLM` is https://huggingface.co/mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B
+        let vb = if vb.contains_tensor("model.embed_tokens.weight") {
+            vb.pp("model")
+        } else {
+            vb
+        };
 
         let embeddings = Embedding::new(
             vb.pp("embed_tokens")

--- a/backends/candle/src/models/flash_qwen2.rs
+++ b/backends/candle/src/models/flash_qwen2.rs
@@ -21,8 +21,8 @@ struct Qwen2Attention {
 
 impl Qwen2Attention {
     pub fn load(vb: VarBuilder, config: &Qwen2Config) -> Result<Self> {
-        if config.use_sliding_window {
-            candle::bail!("Sliding window is not supported");
+        if config.sliding_window.is_some() {
+            candle::bail!("Sliding window is not supported for Qwen2");
         }
 
         let num_attention_heads = config.num_attention_heads;

--- a/backends/candle/src/models/qwen2.rs
+++ b/backends/candle/src/models/qwen2.rs
@@ -14,4 +14,5 @@ pub struct Qwen2Config {
     pub rms_norm_eps: f32,
     pub rope_theta: f32,
     pub sliding_window: Option<usize>,
+    pub use_sliding_window: bool,
 }

--- a/backends/candle/src/models/qwen2.rs
+++ b/backends/candle/src/models/qwen2.rs
@@ -13,6 +13,5 @@ pub struct Qwen2Config {
     pub max_position_embeddings: usize,
     pub rms_norm_eps: f32,
     pub rope_theta: f32,
-    pub sliding_window: usize,
-    pub use_sliding_window: bool,
+    pub sliding_window: Option<usize>,
 }


### PR DESCRIPTION
# What does this PR do?

This PR makes the `sliding_window` to be `Option<usize>` instead of `usize` as it can be set to `null`; additionally, the `model` prefix is only pushed for `FlashQwen2` if available, as the `Qwen2` model does not come with the prefix since it's an instance of `Qwen2Model` not `Qwen2ModelForCausalLM`, meaning that it doesn't have neither the `lm_head` nor the `model` prefix.

This PR then enables models as e.g. https://huggingface.co/mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B (also Azure asked us to add support for this model and a recent discussion has been opened at https://huggingface.co/mims-harvard/ToolRAG-T1-GTE-Qwen2-1.5B/discussions/1, which is unrelated as they are trying to use TGI instead of TEI, but that would unlock serving this model).

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@Narsil (and @pagezyhf for context on the Azure support)