### PR TITLE
Fix typos / formatting in CLI args in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Options:
           [env: HOSTNAME=]
           [default: 0.0.0.0]
 
-  -p, --port <PORT>
+      -p, --port <PORT>
           The port to listen on
 
           [env: PORT=]

--- a/docs/source/en/cli_arguments.md
+++ b/docs/source/en/cli_arguments.md
@@ -131,8 +131,8 @@ Options:
 
           [env: DEFAULT_PROMPT=]
 
-      --hf-api-token <HF_TOKEN>
-          Your HuggingFace hub token
+      --hf-token <HF_TOKEN>
+          Your Hugging Face Hub token
 
           [env: HF_TOKEN=]
 

--- a/docs/source/en/cli_arguments.md
+++ b/docs/source/en/cli_arguments.md
@@ -142,7 +142,7 @@ Options:
           [env: HOSTNAME=]
           [default: 0.0.0.0]
 
-  -p, --port <PORT>
+      -p, --port <PORT>
           The port to listen on
 
           [env: PORT=]


### PR DESCRIPTION
# What does this PR do?

This PR fixes a typo in `--hf-token` as it was still pointing to the to-be-deprecated `--hf-api-token` argument, and also fixes the indentation of the `-p/--port` argument when showed as the `text-embeddings-inference --help` output.

P.S. I recall this was dynamically generated in text-generation-inference, right @Narsil?

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@Narsil