### PR TITLE
Optimize the performance of FlashBert on HPU by using fast mode softmax

### DIFF
--- a/backends/python/server/text_embeddings_server/models/flash_bert.py
+++ b/backends/python/server/text_embeddings_server/models/flash_bert.py
@@ -322,11 +322,10 @@ class FlashBert(Model):
     @tracer.start_as_current_span("embed")
     def embed(self, batch: Union[FlashBatch, PaddedBatch]) -> List[Embedding]:
         if isinstance(batch, PaddedBatch):
-            cumsum_lens = batch.attention_mask.cumsum(-1)
-            input_lens = cumsum_lens[:, -1].to(dtype=torch.int32)
+            input_lens = batch.attention_mask.cumsum(-1)[:, -1].to(torch.int32)
             max_input_lens = input_lens.max().item()
             cu_seqlens = torch.cat(
-                (torch.zeros(1, dtype=torch.int32, device=input_lens.device), cumsum_lens.view(-1).to(torch.int32))
+                (input_lens.new_tensor([0]), input_lens.cumsum(-1).int())
             )
             mask = batch.attention_mask.bool()
             batch_size = input_lens.size(0)

--- a/backends/python/server/text_embeddings_server/utils/flash_attn.py
+++ b/backends/python/server/text_embeddings_server/utils/flash_attn.py
@@ -78,7 +78,7 @@ def hpu_attn(
     if is_causal:
         attn_mask = None
 
-    out_ = FusedSDPA.apply(q, k, v, attn_mask, 0.0, is_causal, softmax_scale)
+    out_ = FusedSDPA.apply(q, k, v, attn_mask, 0.0, is_causal, softmax_scale, "fast", False)
     out_ = out_.transpose(1, 2)
     out.copy_(out_)
     return out


### PR DESCRIPTION
Using model `WhereIsAI/UAE-Large-V1` to do a benchmark, this implementation can get ~1.06x throughput than original one