### PR TITLE
Use custom `serde` deserializer for JinaBERT models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,9 +872,10 @@ dependencies = [
 [[package]]
 name = "cudarc"
 version = "0.13.5"
-source = "git+https://github.com/Narsil/cudarc?rev=b2d6443329e559e9580204b55ecaf44cd6fb6d90#b2d6443329e559e9580204b55ecaf44cd6fb6d90"
+source = "git+https://github.com/Narsil/cudarc?rev=8b4f18b4bcd5e4b1a9daf40abc3a2e27f83f06e9#8b4f18b4bcd5e4b1a9daf40abc3a2e27f83f06e9"
 dependencies = [
  "half",
+ "lazy_static",
 ]
 
 [[package]]


### PR DESCRIPTION
# What does this PR do?

> [!NOTE]
> This PR is still being tested and is missing the tests to be included within this PR.

This PR "improves" the handling for the JinaBERT configurations as those share the same `model_type` as the default BERT models i.e. `model_type=bert` meaning that those need a specific handling for telling apart JinaBERT and BERT. Apparently, when fine-tuning or re-uploading JinaBERT models with Sentence Transformers, the `_name_or_path` value is overwritten with the actual path to the origin Hugging Face Hub repository, which means that the serde-based tag strategy to tell those apart will no longer work, as the value won't match the former check. This PR then, adds a custom `serde` deserializer to make sure that the `config.json` is deserialized for the correct model not only based on the `_name_or_path` value but also on the `auto_map.AutoConfig` value, which in any case will still point to the remote repository with the JinaBERT implementation.

Fixes #556 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@Narsil or @McPatate 