### PR TITLE
Fix `{Bert,DistilBert}SpladeHead` when loading from Safetensors

### DIFF
--- a/backends/candle/src/models/bert.rs
+++ b/backends/candle/src/models/bert.rs
@@ -474,11 +474,12 @@ pub struct BertSpladeHead {
 
 impl BertSpladeHead {
     pub(crate) fn load(vb: VarBuilder, config: &BertConfig) -> Result<Self> {
-        let vb = vb.pp("cls.predictions");
         let transform_weight = vb
-            .pp("transform.dense")
+            .pp("cls.predictions.transform.dense")
             .get((config.hidden_size, config.hidden_size), "weight")?;
-        let transform_bias = vb.pp("transform.dense").get(config.hidden_size, "bias")?;
+        let transform_bias = vb
+            .pp("cls.predictions.transform.dense")
+            .get(config.hidden_size, "bias")?;
         let transform = Linear::new(
             transform_weight,
             Some(transform_bias),
@@ -486,15 +487,26 @@ impl BertSpladeHead {
         );
 
         let transform_layer_norm = LayerNorm::load(
-            vb.pp("transform.LayerNorm"),
+            vb.pp("cls.predictions.transform.LayerNorm"),
             config.hidden_size,
             config.layer_norm_eps as f32,
         )?;
 
-        let decoder_weight = vb
-            .pp("decoder")
-            .get((config.vocab_size, config.hidden_size), "weight")?;
-        let decoder_bias = vb.get(config.vocab_size, "bias")?;
+        // When `pytorch_model.bin` originally contains `cls.predictions.decoder.weight`, but since
+        // the tensor content is duplicated with the content on `bert.embeddings.word_embeddings.weight`
+        // when converting the file from BIN to Safentensors, the duplicated tensors are removed,
+        // meaning that we need to capture both alternatives to handle both BIN and Safentensors
+        // files for models with Splade pooling
+        let decoder_weight = if vb.contains_tensor("cls.predictions.decoder.weight") {
+            vb.pp("cls.predictions.decoder")
+                .get((config.vocab_size, config.hidden_size), "weight")?
+        } else {
+            vb.pp("bert.embeddings.word_embeddings")
+                .get((config.vocab_size, config.hidden_size), "weight")?
+        };
+        // Same applies for the tensor `cls.predictions.decoder.bias` which is duplicated with
+        // `cls.predictions.bias` and removed in the BIN to Safentensors conversion
+        let decoder_bias = vb.get(config.vocab_size, "cls.predictions.bias")?;
         let decoder = Linear::new(decoder_weight, Some(decoder_bias), Some(HiddenAct::Relu));
 
         Ok(Self {

--- a/backends/candle/src/models/bert.rs
+++ b/backends/candle/src/models/bert.rs
@@ -492,8 +492,8 @@ impl BertSpladeHead {
             config.layer_norm_eps as f32,
         )?;
 
-        // When `pytorch_model.bin` originally contains `cls.predictions.decoder.weight`, but since
-        // the tensor content is duplicated with the content on `bert.embeddings.word_embeddings.weight`
+        // When `pytorch_model.bin` originally contains `cls.predictions.decoder.weight` but the
+        // tensor content is duplicated with the content on `bert.embeddings.word_embeddings.weight`
         // when converting the file from BIN to Safentensors, the duplicated tensors are removed,
         // meaning that we need to capture both alternatives to handle both BIN and Safentensors
         // files for models with Splade pooling

--- a/backends/candle/src/models/bert.rs
+++ b/backends/candle/src/models/bert.rs
@@ -506,7 +506,7 @@ impl BertSpladeHead {
         };
         // Same applies for the tensor `cls.predictions.decoder.bias` which is duplicated with
         // `cls.predictions.bias` and removed in the BIN to Safentensors conversion
-        let decoder_bias = vb.get(config.vocab_size, "cls.predictions.bias")?;
+        let decoder_bias = vb.pp("cls.predictions").get(config.vocab_size, "bias")?;
         let decoder = Linear::new(decoder_weight, Some(decoder_bias), Some(HiddenAct::Relu));
 
         Ok(Self {

--- a/backends/candle/src/models/distilbert.rs
+++ b/backends/candle/src/models/distilbert.rs
@@ -391,9 +391,18 @@ impl DistilBertSpladeHead {
             Some(config.activation.clone()),
         );
 
-        let vocab_projector_weight = vb
-            .pp("vocab_projector")
-            .get((config.vocab_size, config.dim), "weight")?;
+        // When `pytorch_model.bin` originally contains `vocab_projector.weight` but the tensor
+        // content is duplicated with the content on `distilbert.embeddings.word_embeddings.weight`
+        // when converting the file from BIN to Safentensors, the duplicated tensors are removed,
+        // meaning that we need to capture both alternatives to handle both BIN and Safentensors
+        // files for models with Splade pooling
+        let vocab_projector_weight = if vb.contains_tensor("vocab_projector.weight") {
+            vb.pp("vocab_projector")
+                .get((config.vocab_size, config.dim), "weight")?
+        } else {
+            vb.pp("distilbert.embeddings.word_embeddings")
+                .get((config.vocab_size, config.dim), "weight")?
+        };
         let vocab_projector_bias = vb.pp("vocab_projector").get(config.vocab_size, "bias")?;
         let vocab_projector = Linear::new(
             vocab_projector_weight,

--- a/backends/candle/src/models/distilbert.rs
+++ b/backends/candle/src/models/distilbert.rs
@@ -392,10 +392,9 @@ impl DistilBertSpladeHead {
         );
 
         // When `pytorch_model.bin` originally contains `vocab_projector.weight` but the tensor
-        // content is duplicated with the content on `distilbert.embeddings.word_embeddings.weight`
-        // when converting the file from BIN to Safentensors, the duplicated tensors are removed,
-        // meaning that we need to capture both alternatives to handle both BIN and Safentensors
-        // files for models with Splade pooling
+        // content shares the memory with the content on `distilbert.embeddings.word_embeddings.weight`,
+        // e.g. a subset of the original tensor, when converting the file from BIN to Safentensors
+        // the latter tensor that shares the memory with the previous will be removed
         let vocab_projector_weight = if vb.contains_tensor("vocab_projector.weight") {
             vb.pp("vocab_projector")
                 .get((config.vocab_size, config.dim), "weight")?


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue preventing loading BERT and DistilBERT models with the SPLADE pooling, as when converting the `pytorch_model.bin` into a `model.safetensors` files, the tensors with shared memory for the content are removed for safety, meaning that the required weights for the SPLADE head were not there, as support for SPLADE was originally introduced for the models at https://huggingface.co/naver which are indeed `pytorch_model.bin` files.

So on, this PR bypasses that by adding a check on whether the required tensors are there, and if not, it falls back to the tensor with the shared memory instead.

To reproduce the issue, simply grab any model under https://huggingface.co/naver as e.g. `naver/efficient-splade-V-large-query` and download the `pytorch_model.bin` file and then convert it into a `model.safetensors` file with the following script:

```python
import torch
from safetensors.torch import save_file

model_state_dict = torch.load("pytorch_model.bin", map_location=torch.device("cpu"))
contiguous_state_dict = {k: v.contiguous() for k, v in model_state_dict.items()}

save_file(contiguous_state_dict, "model.safetensors")
```

Then the following error will be raised:

```console
Some tensors share memory, this will lead to duplicate memory on disk and potential differences when loading them again: [{'distilbert.embeddings.word_embeddings.weight', 'vocab_projector.weight'}].
A potential way to correctly save your model is to use `save_model`.
More information at https://huggingface.co/docs/safetensors/torch_shared_tensors
```

And indeed if we inspect the `model.safetensors` metadata, we'll see that the latter tensor that shares memory with a previous tensor won't be there.

Fixes #548

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@Narsil or @McPatate 