### PR TITLE
Adding missing `head.` prefix in the weight name in `ModernBertClassificationHead`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Below are some examples of the currently supported models:
 | Re-Ranking         | XLM-RoBERTa | [BAAI/bge-reranker-large](https://huggingface.co/BAAI/bge-reranker-large)                                       |
 | Re-Ranking         | XLM-RoBERTa | [BAAI/bge-reranker-base](https://huggingface.co/BAAI/bge-reranker-base)                                         |
 | Re-Ranking         | GTE         | [Alibaba-NLP/gte-multilingual-reranker-base](https://huggingface.co/Alibaba-NLP/gte-multilingual-reranker-base) |
+| Re-Ranking         | ModernBert  | [Alibaba-NLP/gte-reranker-modernbert-base](https://huggingface.co/Alibaba-NLP/gte-reranker-modernbert-base) |
 | Sentiment Analysis | RoBERTa     | [SamLowe/roberta-base-go_emotions](https://huggingface.co/SamLowe/roberta-base-go_emotions)                     |
 
 ### Docker

--- a/backends/candle/src/models/modernbert.rs
+++ b/backends/candle/src/models/modernbert.rs
@@ -412,24 +412,27 @@ pub struct ModernBertClassificationHead {
 impl ModernBertClassificationHead {
     pub(crate) fn load(vb: VarBuilder, config: &ModernBertConfig) -> Result<Self> {
         let dense_weight = vb
-            .pp("dense")
+            .pp("head.dense")
             .get((config.hidden_size, config.hidden_size), "weight")?;
-        let dense_bias = vb.pp("dense").get(config.hidden_size, "bias").ok();
+        let dense_bias = vb.pp("head.dense").get(config.hidden_size, "bias").ok();
         let dense = Linear::new(
             dense_weight,
             dense_bias,
             Some(config.classifier_activation.clone()),
         );
 
-        let norm =
-            LayerNormNoBias::load(vb.pp("norm"), config.hidden_size, config.norm_eps as f32)?;
+        let norm = LayerNormNoBias::load(
+            vb.pp("head.norm"),
+            config.hidden_size,
+            config.norm_eps as f32,
+        )?;
 
-        let classifier_weight = vb.pp("dense").get(
+        let classifier_weight = vb.pp("classifier").get(
             (config.num_labels.unwrap_or(1), config.hidden_size),
             "weight",
         )?;
         let classifier_bias = vb
-            .pp("dense")
+            .pp("classifier")
             .get(config.num_labels.unwrap_or(1), "bias")
             .ok();
         let classifier = Linear::new(classifier_weight, classifier_bias, None);

--- a/backends/candle/src/models/modernbert.rs
+++ b/backends/candle/src/models/modernbert.rs
@@ -414,10 +414,9 @@ impl ModernBertClassificationHead {
         let dense_weight = vb
             .pp("head.dense")
             .get((config.hidden_size, config.hidden_size), "weight")?;
-        let dense_bias = vb.pp("head.dense").get(config.hidden_size, "bias").ok();
         let dense = Linear::new(
             dense_weight,
-            dense_bias,
+            None,
             Some(config.classifier_activation.clone()),
         );
 
@@ -433,9 +432,8 @@ impl ModernBertClassificationHead {
         )?;
         let classifier_bias = vb
             .pp("classifier")
-            .get(config.num_labels.unwrap_or(1), "bias")
-            .ok();
-        let classifier = Linear::new(classifier_weight, classifier_bias, None);
+            .get(config.num_labels.unwrap_or(1), "bias")?;
+        let classifier = Linear::new(classifier_weight, Some(classifier_bias), None);
 
         Ok(Self {
             dense,

--- a/backends/candle/tests/snapshots/test_modernbert__modernbert_classification_single.snap
+++ b/backends/candle/tests/snapshots/test_modernbert__modernbert_classification_single.snap
@@ -1,0 +1,5 @@
+---
+source: backends/candle/tests/test_modernbert.rs
+expression: predictions_single
+---
+- - 2.2585099

--- a/backends/candle/tests/test_modernbert.rs
+++ b/backends/candle/tests/test_modernbert.rs
@@ -148,13 +148,7 @@ fn test_modernbert_classification() -> Result<()> {
 
     let input_single = batch(
         vec![tokenizer
-            .encode(
-                (
-                    "PrimeTime is a timing signoff tool",
-                    "PrimeTime can perform most accurate timing analysis",
-                ),
-                true,
-            )
+            .encode(("What is Deep Learning?", "Deep Learning is not..."), true)
             .unwrap()],
         [0].to_vec(),
         vec![],


### PR DESCRIPTION
# What does this PR do?

Adding the missing `head.` prefix in the key name of the weight in the `ModernBertClassificationhead`. and adding the test case.

```
text-embeddings-router --model-id ../gte-reranker-modernbert-base/ --pooling cls --port 8080 --dtype float32 --auto-truncate
2025-04-18T06:51:43.264617Z  INFO text_embeddings_router: router/src/main.rs:185: Args { model_id: "../gte-********-**********-*ase/", revision: None, tokenization_workers: None, dtype: Some(Float32), pooling: Some(Cls), max_concurrent_requests: 512, max_batch_tokens: 16384, max_batch_requests: None, max_client_batch_size: 32, auto_truncate: true, default_prompt_name: None, default_prompt: None, hf_api_token: None, hf_token: None, hostname: "0.0.0.0", port: 8080, uds_path: "/tmp/text-embeddings-inference-server", huggingface_hub_cache: None, payload_limit: 2000000, api_key: None, json_output: false, disable_spans: false, otlp_endpoint: None, otlp_service_name: "text-embeddings-inference.server", cors_allow_origin: None }
2025-04-18T06:51:43.264729Z  WARN text_embeddings_router: router/src/lib.rs:372: `--pooling` arg is set but model is a classifier. Ignoring `--pooling` arg.
2025-04-18T06:51:43.338940Z  WARN text_embeddings_router: router/src/lib.rs:188: Could not find a Sentence Transformers config
2025-04-18T06:51:43.338978Z  INFO text_embeddings_router: router/src/lib.rs:192: Maximum number of tokens per request: 8192
2025-04-18T06:51:43.339103Z  INFO text_embeddings_core::tokenization: core/src/tokenization.rs:38: Starting 8 tokenization workers
2025-04-18T06:51:43.400860Z  INFO text_embeddings_router: router/src/lib.rs:234: Starting model backend
2025-04-18T06:51:43.401443Z  INFO text_embeddings_backend_candle: backends/candle/src/lib.rs:281: Starting ModernBert model on Cpu
2025-04-18T06:51:43.629142Z  WARN text_embeddings_router: router/src/lib.rs:262: Backend does not support a batch size > 4
2025-04-18T06:51:43.629167Z  WARN text_embeddings_router: router/src/lib.rs:263: forcing `max_batch_requests=4`
2025-04-18T06:51:43.630357Z  INFO text_embeddings_router::http::server: router/src/http/server.rs:1795: Starting HTTP server: 0.0.0.0:8080
2025-04-18T06:51:43.630387Z  INFO text_embeddings_router::http::server: router/src/http/server.rs:1796: Ready
```

Fixes #590

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil @alvarobartt @michaelfeil