### PR TITLE
Remove duplicate short option '-p' to fix router executable

### DIFF
--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -165,7 +165,7 @@ struct Args {
     otlp_service_name: String,
 
     /// The Prometheus port to listen on.
-    #[clap(default_value = "9000", long, short, env)]
+    #[clap(default_value = "9000", long, env)]
     prometheus_port: u16,
 
     /// Unused for gRPC servers


### PR DESCRIPTION
Fixes #601 which appears to be a regression caused by #589.