### PR TITLE
Fix the weight name in GTEClassificationHead

### DIFF
--- a/backends/candle/tests/snapshots/test_flash_gte__gte_classification_single.snap
+++ b/backends/candle/tests/snapshots/test_flash_gte__gte_classification_single.snap
@@ -1,6 +1,5 @@
 ---
 source: backends/candle/tests/test_flash_gte.rs
-assertion_line: 83
 expression: predictions_single
 ---
-- - 0.050048828
+- - -0.7426758

--- a/backends/candle/tests/snapshots/test_gte__gte_classification_single.snap
+++ b/backends/candle/tests/snapshots/test_gte__gte_classification_single.snap
@@ -1,0 +1,5 @@
+---
+source: backends/candle/tests/test_gte.rs
+expression: predictions_single
+---
+- - -0.74173266

--- a/backends/candle/tests/test_gte.rs
+++ b/backends/candle/tests/test_gte.rs
@@ -1,8 +1,8 @@
 mod common;
 
-use crate::common::{sort_embeddings, SnapshotEmbeddings};
+use crate::common::{sort_embeddings, SnapshotEmbeddings, SnapshotScores};
 use anyhow::Result;
-use common::{batch, cosine_matcher, download_artifacts, load_tokenizer};
+use common::{batch, cosine_matcher, download_artifacts, load_tokenizer, relative_matcher};
 use text_embeddings_backend_candle::CandleBackend;
 use text_embeddings_backend_core::{Backend, ModelType, Pool};
 
@@ -134,6 +134,35 @@ fn test_snowflake_gte() -> Result<()> {
     insta::assert_yaml_snapshot!("snowflake_gte_single", embeddings_single, &matcher);
     assert_eq!(embeddings_batch[0], embeddings_single[0]);
     assert_eq!(embeddings_batch[2], embeddings_single[0]);
+
+    Ok(())
+}
+
+#[test]
+#[serial_test::serial]
+fn test_gte_classification() -> Result<()> {
+    let model_root = download_artifacts("Alibaba-NLP/gte-multilingual-reranker-base", None)?;
+    let tokenizer = load_tokenizer(&model_root)?;
+
+    let backend = CandleBackend::new(&model_root, "float32".to_string(), ModelType::Classifier)?;
+
+    let input_single = batch(
+        vec![tokenizer
+            .encode(("What is Deep Learning?", "Deep Learning is not..."), true)
+            .unwrap()],
+        [0].to_vec(),
+        vec![],
+    );
+
+    let predictions: Vec<Vec<f32>> = backend
+        .predict(input_single)?
+        .into_iter()
+        .map(|(_, v)| v)
+        .collect();
+    let predictions_single = SnapshotScores::from(predictions);
+
+    let matcher = relative_matcher();
+    insta::assert_yaml_snapshot!("gte_classification_single", predictions_single, &matcher);
 
     Ok(())
 }


### PR DESCRIPTION
# What does this PR do?

Fixes #605

The `pooler` layer loads its weight using an incorrect key name, causing the classifier and reranker based on GTE to produce wrong outputs.

## changelog

- [x] load the weight from `new.pooler.dense.*` or `pooler.dense.*`
- [x] add the tests
- [x] update the flash gte test

## tests

I've checked that the outputs are aligned with the HF models.

- [x] `WebOrganizer/FormatClassifier`
- [x] `Alibaba-NLP/gte-multilingual-reranker-base`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil @alvarobartt 