### PR TITLE
Patch DistilBERT variants with different weight keys

### DIFF
--- a/backends/candle/src/models/distilbert.rs
+++ b/backends/candle/src/models/distilbert.rs
@@ -475,6 +475,11 @@ impl DistilBertModel {
                     DistilBertEncoder::load(vb.pp("distilbert.transformer"), config),
                 ) {
                     (embeddings, encoder)
+                } else if let (Ok(embeddings), Ok(encoder)) = (
+                    DistilBertEmbeddings::load(vb.pp("embeddings"), config),
+                    DistilBertEncoder::load(vb.pp("transformer"), config),
+                ) {
+                    (embeddings, encoder)
                 } else {
                     return Err(err);
                 }

--- a/backends/candle/src/models/flash_distilbert.rs
+++ b/backends/candle/src/models/flash_distilbert.rs
@@ -213,6 +213,11 @@ impl FlashDistilBertModel {
                     DistilBertEncoder::load(vb.pp("distilbert.transformer"), config),
                 ) {
                     (embeddings, encoder)
+                } else if let (Ok(embeddings), Ok(encoder)) = (
+                    DistilBertEmbeddings::load(vb.pp("embeddings"), config),
+                    DistilBertEncoder::load(vb.pp("transformer"), config),
+                ) {
+                    (embeddings, encoder)
                 } else {
                     return Err(err);
                 }


### PR DESCRIPTION
# What does this PR do?

This PR adds a missing DistilBERT variant on weight naming so that it can also be loaded in Text Embeddings Inference (TEI). Apparently, the weight naming issue is persistent across all the DistilBERT models on https://huggingface.co/sentence-transformers, so this PR should solve that and enable all the Sentence Transformers models with the DistilBERT architecture (note that those do appear as currently supported because the architecture is indeed supported but without this patch the deployment would fail). See e.g. https://huggingface.co/sentence-transformers/distiluse-base-multilingual-cased-v2.

Fixes #600 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@Narsil