### PR TITLE
Add mean pooling strategy for Modernbert classifier

### DIFF
--- a/backends/candle/src/models/flash_modernbert.rs
+++ b/backends/candle/src/models/flash_modernbert.rs
@@ -260,7 +260,15 @@ impl FlashModernBertModel {
 
         let (pool, classifier) = match model_type {
             ModelType::Classifier => {
-                let pool = Pool::Cls;
+                let pool = if let Some(pooling) = &config.classifier_pooling {
+                    match pooling.as_str() {
+                        "cls" => Pool::Cls,
+                        "mean" => Pool::Mean,
+                        _ => Pool::Cls,
+                    }
+                } else {
+                    Pool::Cls
+                };
 
                 let classifier: Box<dyn ClassificationHead + Send> =
                     Box::new(ModernBertClassificationHead::load(vb.clone(), config)?);

--- a/backends/candle/src/models/flash_modernbert.rs
+++ b/backends/candle/src/models/flash_modernbert.rs
@@ -260,15 +260,11 @@ impl FlashModernBertModel {
 
         let (pool, classifier) = match model_type {
             ModelType::Classifier => {
-                let pool = if let Some(pooling) = &config.classifier_pooling {
-                    match pooling.as_str() {
-                        "cls" => Pool::Cls,
-                        "mean" => Pool::Mean,
-                        _ => Pool::Cls,
-                    }
-                } else {
-                    Pool::Cls
-                };
+                let pool: Pool = config
+                    .classifier_pooling
+                    .as_deref()
+                    .and_then(|s| Pool::from_str(s).ok())
+                    .unwrap_or(Pool::Cls);
 
                 let classifier: Box<dyn ClassificationHead + Send> =
                     Box::new(ModernBertClassificationHead::load(vb.clone(), config)?);

--- a/backends/candle/src/models/modernbert.rs
+++ b/backends/candle/src/models/modernbert.rs
@@ -484,7 +484,15 @@ impl ModernBertModel {
     pub fn load(vb: VarBuilder, config: &ModernBertConfig, model_type: ModelType) -> Result<Self> {
         let (pool, classifier) = match model_type {
             ModelType::Classifier => {
-                let pool = Pool::Cls;
+                let pool = if let Some(pooling) = &config.classifier_pooling {
+                    match pooling.as_str() {
+                        "cls" => Pool::Cls,
+                        "mean" => Pool::Mean,
+                        _ => Pool::Cls,
+                    }
+                } else {
+                    Pool::Cls
+                };
 
                 let classifier: Box<dyn ClassificationHead + Send> =
                     Box::new(ModernBertClassificationHead::load(vb.clone(), config)?);

--- a/backends/candle/src/models/modernbert.rs
+++ b/backends/candle/src/models/modernbert.rs
@@ -7,6 +7,7 @@ use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
 use candle_nn::{Embedding, VarBuilder};
 use serde::Deserialize;
 use text_embeddings_backend_core::{Batch, ModelType, Pool};
+use std::str::FromStr;
 
 // https://github.com/huggingface/transformers/blob/main/src/transformers/models/modernbert/configuration_modernbert.py
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -484,15 +485,11 @@ impl ModernBertModel {
     pub fn load(vb: VarBuilder, config: &ModernBertConfig, model_type: ModelType) -> Result<Self> {
         let (pool, classifier) = match model_type {
             ModelType::Classifier => {
-                let pool = if let Some(pooling) = &config.classifier_pooling {
-                    match pooling.as_str() {
-                        "cls" => Pool::Cls,
-                        "mean" => Pool::Mean,
-                        _ => Pool::Cls,
-                    }
-                } else {
-                    Pool::Cls
-                };
+                let pool: Pool = config
+                    .classifier_pooling
+                    .as_deref()
+                    .and_then(|s| Pool::from_str(s).ok())
+                    .unwrap_or(Pool::Cls);
 
                 let classifier: Box<dyn ClassificationHead + Send> =
                     Box::new(ModernBertClassificationHead::load(vb.clone(), config)?);

--- a/backends/candle/tests/snapshots/test_modernbert__modernbert_classification_mean_pooling.snap.new
+++ b/backends/candle/tests/snapshots/test_modernbert__modernbert_classification_mean_pooling.snap.new
@@ -1,0 +1,7 @@
+---
+source: backends/candle/tests/test_modernbert.rs
+assertion_line: 229
+expression: predictions_single
+---
+- - -0.30617672
+

--- a/backends/candle/tests/snapshots/test_modernbert__modernbert_classifier_mean_pooling.snap
+++ b/backends/candle/tests/snapshots/test_modernbert__modernbert_classifier_mean_pooling.snap
@@ -1,5 +1,0 @@
----
-source: backends/candle/tests/test_modernbert.rs
-expression: predictions_single
----
-- - -0.30617672

--- a/backends/candle/tests/snapshots/test_modernbert__modernbert_classifier_mean_pooling.snap
+++ b/backends/candle/tests/snapshots/test_modernbert__modernbert_classifier_mean_pooling.snap
@@ -1,7 +1,5 @@
 ---
 source: backends/candle/tests/test_modernbert.rs
-assertion_line: 229
 expression: predictions_single
 ---
 - - -0.30617672
-

--- a/backends/candle/tests/test_modernbert.rs
+++ b/backends/candle/tests/test_modernbert.rs
@@ -205,17 +205,10 @@ fn test_modernbert_classification() -> Result<()> {
 
 #[test]
 #[serial_test::serial]
-fn test_modernbert_classifier_pooling_strategy() -> Result<()> {
-    let model_root = download_artifacts("Alibaba-NLP/gte-reranker-modernbert-base", None)?;
+fn test_modernbert_classifier_mean_pooling() -> Result<()> {
+    let model_root = download_artifacts("tomaarsen/reranker-ModernBERT-large-gooaq-bce", None)?;
     let tokenizer = load_tokenizer(&model_root)?;
-
-    let config_path = model_root.join("config.json");
-    let original_config: serde_json::Value = {
-        let config_content = fs::read_to_string(&config_path)?;
-        serde_json::from_str(&config_content)?
-    };
-
-    assert_eq!(original_config["classifier_pooling"], "mean");
+    let backend = CandleBackend::new(&model_root, "float32".to_string(), ModelType::Classifier)?;
 
     let input_single = batch(
         vec![tokenizer
@@ -225,36 +218,17 @@ fn test_modernbert_classifier_pooling_strategy() -> Result<()> {
         vec![],
     );
 
-    let backend_mean = CandleBackend::new(&model_root, "float32".to_string(), ModelType::Classifier)?;
-    let predictions_mean: Vec<Vec<f32>> = backend_mean
-        .predict(input_single.clone())?
-        .into_iter()
-        .map(|(_, v)| v)
-        .collect();
-
-    let mut config = original_config.clone();
-    config["classifier_pooling"] = json!("cls");
-    fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
-
-    let backend_cls = CandleBackend::new(&model_root, "float32".to_string(), ModelType::Classifier)?;
-    let predictions_cls: Vec<Vec<f32>> = backend_cls
+    let predictions: Vec<Vec<f32>> = backend
         .predict(input_single)?
         .into_iter()
         .map(|(_, v)| v)
         .collect();
-
-    fs::write(&config_path, serde_json::to_string_pretty(&original_config)?)?;
-
-    assert_ne!(
-        predictions_mean[0], predictions_cls[0],
-        "Mean and CLS pooling should produce different predictions"
-    );
+    let predictions_single = SnapshotScores::from(predictions);
 
     let matcher = relative_matcher();
-    let predictions_snapshot = SnapshotScores::from(predictions_mean);
     insta::assert_yaml_snapshot!(
         "modernbert_classifier_mean_pooling",
-        predictions_snapshot,
+        predictions_single,
         &matcher
     );
 

--- a/backends/candle/tests/test_modernbert.rs
+++ b/backends/candle/tests/test_modernbert.rs
@@ -205,7 +205,7 @@ fn test_modernbert_classification() -> Result<()> {
 
 #[test]
 #[serial_test::serial]
-fn test_modernbert_classifier_mean_pooling() -> Result<()> {
+fn test_modernbert_classification_mean_pooling() -> Result<()> {
     let model_root = download_artifacts("tomaarsen/reranker-ModernBERT-large-gooaq-bce", None)?;
     let tokenizer = load_tokenizer(&model_root)?;
     let backend = CandleBackend::new(&model_root, "float32".to_string(), ModelType::Classifier)?;
@@ -227,7 +227,7 @@ fn test_modernbert_classifier_mean_pooling() -> Result<()> {
 
     let matcher = relative_matcher();
     insta::assert_yaml_snapshot!(
-        "modernbert_classifier_mean_pooling",
+        "modernbert_classification_mean_pooling",
         predictions_single,
         &matcher
     );

--- a/backends/core/src/lib.rs
+++ b/backends/core/src/lib.rs
@@ -2,6 +2,7 @@
 use clap::ValueEnum;
 use nohash_hasher::IntMap;
 use std::fmt;
+use std::str::FromStr;
 use thiserror::Error;
 
 #[derive(Debug)]
@@ -74,6 +75,23 @@ impl fmt::Display for Pool {
             Pool::Mean => write!(f, "mean"),
             Pool::Splade => write!(f, "splade"),
             Pool::LastToken => write!(f, "last_token"),
+        }
+    }
+}
+
+impl std::str::FromStr for Pool {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "cls" => Ok(Pool::Cls),
+            "mean" => Ok(Pool::Mean),
+            "splade" => Ok(Pool::Splade),
+            "last_token" => Ok(Pool::LastToken),
+            _ => Err(format!(
+                "Invalid pooling method '{}'. Valid options: cls, mean, splade, last_token", 
+                s
+            )),
         }
     }
 }

--- a/backends/core/src/lib.rs
+++ b/backends/core/src/lib.rs
@@ -2,7 +2,6 @@
 use clap::ValueEnum;
 use nohash_hasher::IntMap;
 use std::fmt;
-use std::str::FromStr;
 use thiserror::Error;
 
 #[derive(Debug)]


### PR DESCRIPTION
# What does this PR do?

Apologies in advance, new this this area and Rust 😅.

I noticed differences between Transformers and TEI libraries when running rerankers with a `mean` classifier pooling strategy. [More details here](https://github.com/huggingface/text-embeddings-inference/issues/615).

Fixes https://github.com/huggingface/text-embeddings-inference/issues/615


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
Not sure who might be best to review 😄  @OlivierDehaene OR @Narsil
