### PR TITLE
Fix `insta` snapshots for ModernBERT tests

### DIFF
--- a/backends/candle/tests/snapshots/test_modernbert__modernbert_classification_mean_pooling.snap
+++ b/backends/candle/tests/snapshots/test_modernbert__modernbert_classification_mean_pooling.snap
@@ -1,7 +1,5 @@
 ---
 source: backends/candle/tests/test_modernbert.rs
-assertion_line: 229
 expression: predictions_single
 ---
-- - -0.30617672
-
+- - -0.30616543

--- a/backends/candle/tests/snapshots/test_modernbert__modernbert_classification_single.snap
+++ b/backends/candle/tests/snapshots/test_modernbert__modernbert_classification_single.snap
@@ -2,4 +2,4 @@
 source: backends/candle/tests/test_modernbert.rs
 expression: predictions_single
 ---
-- - 2.2585099
+- - 2.136162


### PR DESCRIPTION
# What does this PR do?

This PR fixes the `insta` snapshots for ModernBERT as upon the merge of #616 the tests were failing on `main` as per https://github.com/huggingface/text-embeddings-inference/actions/runs/15394613692/job/43312063692.

To update the `insta` snapshots in this PR, we ran `cargo test --release -F candle --test test_modernbert` and then `cargo insta review` to review and accept the updated / fixed snapshots.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@Narsil