### PR TITLE
Add `HiddenAct::Silu` (remove `serde` alias)

### DIFF
--- a/backends/candle/src/layers/linear.rs
+++ b/backends/candle/src/layers/linear.rs
@@ -17,7 +17,7 @@ impl HiddenAct {
             Self::Gelu => x.gelu(),
             Self::Relu => x.relu(),
             Self::Silu => x.silu(),
-            Self::Swiglu => candle_nn::ops::swiglu(&x),
+            Self::Swiglu => candle_nn::ops::swiglu(x),
         }
     }
 }

--- a/backends/candle/src/layers/linear.rs
+++ b/backends/candle/src/layers/linear.rs
@@ -16,7 +16,9 @@ impl HiddenAct {
         match self {
             Self::Gelu => x.gelu(),
             Self::Relu => x.relu(),
-            Self::Swiglu => candle_nn::ops::swiglu(x),
+            // NOTE: use SiLU instead candle's SwiGLU, as SwiGLU is SiLU + down projection
+            // to half size since we split on intermediate dimension
+            Self::Swiglu => x.silu(),
         }
     }
 }
@@ -80,7 +82,9 @@ impl Linear {
                 match act {
                     HiddenAct::Gelu => x.gelu(),
                     HiddenAct::Relu => x.relu(),
-                    HiddenAct::Swiglu => candle_nn::ops::swiglu(&x),
+                    // NOTE: use SiLU instead candle's SwiGLU, as SwiGLU is SiLU + down projection
+                    // to half size since we split on intermediate dimension
+                    HiddenAct::Swiglu => x.silu(),
                 }
             } else {
                 Ok(x)

--- a/backends/candle/src/layers/linear.rs
+++ b/backends/candle/src/layers/linear.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 pub enum HiddenAct {
     Gelu,
     Relu,
-    #[serde(alias = "silu")]
+    Silu,
     Swiglu,
 }
 
@@ -16,9 +16,8 @@ impl HiddenAct {
         match self {
             Self::Gelu => x.gelu(),
             Self::Relu => x.relu(),
-            // NOTE: use SiLU instead candle's SwiGLU, as SwiGLU is SiLU + down projection
-            // to half size since we split on intermediate dimension
-            Self::Swiglu => x.silu(),
+            Self::Silu => x.silu(),
+            Self::Swiglu => candle_nn::ops::swiglu(&x),
         }
     }
 }
@@ -82,9 +81,8 @@ impl Linear {
                 match act {
                     HiddenAct::Gelu => x.gelu(),
                     HiddenAct::Relu => x.relu(),
-                    // NOTE: use SiLU instead candle's SwiGLU, as SwiGLU is SiLU + down projection
-                    // to half size since we split on intermediate dimension
-                    HiddenAct::Swiglu => x.silu(),
+                    HiddenAct::Silu => x.silu(),
+                    HiddenAct::Swiglu => candle_nn::ops::swiglu(&x),
                 }
             } else {
                 Ok(x)

--- a/backends/candle/src/models/flash_jina.rs
+++ b/backends/candle/src/models/flash_jina.rs
@@ -176,11 +176,7 @@ impl JinaBertLayer {
 
         let hidden_states = self.gated.forward(&hidden_states)?;
         let gated = hidden_states.narrow(1, 0, self.intermediate_size)?;
-        let gated = match self.act {
-            HiddenAct::Gelu => gated.gelu(),
-            HiddenAct::Relu => gated.relu(),
-            HiddenAct::Swiglu => gated.silu(),
-        }?;
+        let gated = self.act.forward(&gated)?;
 
         let non_gated = hidden_states.narrow(1, self.intermediate_size, self.intermediate_size)?;
         let hidden_states = (gated * non_gated)?;

--- a/backends/candle/src/models/flash_jina_code.rs
+++ b/backends/candle/src/models/flash_jina_code.rs
@@ -230,11 +230,7 @@ impl JinaCodeBertLayer {
         let hidden_states = self.up_gated_layer.forward(&hidden_states)?;
         let non_gated = hidden_states.narrow(1, 0, self.intermediate_size)?;
         let gated = hidden_states.narrow(1, self.intermediate_size, self.intermediate_size)?;
-        let gated = match self.act {
-            HiddenAct::Gelu => gated.gelu(),
-            HiddenAct::Relu => gated.relu(),
-            HiddenAct::Swiglu => gated.silu(),
-        }?;
+        let gated = self.act.forward(&gated)?;
         let hidden_states = (non_gated * gated)?;
         let hidden_states = self.down_layer.forward(&hidden_states)?;
 

--- a/backends/candle/src/models/flash_mistral.rs
+++ b/backends/candle/src/models/flash_mistral.rs
@@ -159,11 +159,7 @@ impl MistralMLP {
         let gate_states = gate_up_states.narrow(1, 0, self.intermediate_size)?;
         let up_states = gate_up_states.narrow(1, self.intermediate_size, self.intermediate_size)?;
 
-        let gate_states = match self.act {
-            HiddenAct::Gelu => gate_states.gelu(),
-            HiddenAct::Relu => gate_states.relu(),
-            HiddenAct::Swiglu => gate_states.silu(),
-        }?;
+        let gate_states = self.act.forward(&gate_states)?;
         let r = self.down_proj.forward(&(gate_states * up_states)?);
         r
     }

--- a/backends/candle/src/models/flash_qwen2.rs
+++ b/backends/candle/src/models/flash_qwen2.rs
@@ -167,11 +167,7 @@ impl Qwen2MLP {
         let gate_states = gate_up_states.narrow(1, 0, self.intermediate_size)?;
         let up_states = gate_up_states.narrow(1, self.intermediate_size, self.intermediate_size)?;
 
-        let gate_states = match self.act {
-            HiddenAct::Gelu => gate_states.gelu(),
-            HiddenAct::Relu => gate_states.relu(),
-            HiddenAct::Swiglu => gate_states.silu(),
-        }?;
+        let gate_states = self.act.forward(&gate_states)?;
         let r = self.down_proj.forward(&(gate_states * up_states)?);
         r
     }

--- a/backends/candle/src/models/jina.rs
+++ b/backends/candle/src/models/jina.rs
@@ -294,11 +294,7 @@ impl JinaBertLayer {
 
         let hidden_states = self.gated.forward(&hidden_states)?;
         let gated = hidden_states.i((.., .., 0..self.intermediate_size))?;
-        let gated = match self.act {
-            HiddenAct::Gelu => gated.gelu(),
-            HiddenAct::Relu => gated.relu(),
-            HiddenAct::Swiglu => gated.silu(),
-        }?;
+        let gated = self.act.forward(&gated)?;
 
         let non_gated = hidden_states.i((.., .., self.intermediate_size..))?;
         let hidden_states = (gated * non_gated)?;

--- a/backends/candle/src/models/jina_code.rs
+++ b/backends/candle/src/models/jina_code.rs
@@ -284,11 +284,7 @@ impl JinaCodeBertLayer {
         let hidden_states = self.up_gated_layer.forward(&hidden_states)?;
         let non_gated = hidden_states.i((.., .., 0..self.intermediate_size))?;
         let gated = hidden_states.i((.., .., self.intermediate_size..))?;
-        let gated = match self.act {
-            HiddenAct::Gelu => gated.gelu(),
-            HiddenAct::Relu => gated.relu(),
-            HiddenAct::Swiglu => gated.silu(),
-        }?;
+        let gated = self.act.forward(&gated)?;
         let hidden_states = (non_gated * gated)?;
         let hidden_states = self.down_layer.forward(&hidden_states)?;
 

--- a/backends/candle/src/models/modernbert.rs
+++ b/backends/candle/src/models/modernbert.rs
@@ -120,7 +120,7 @@ impl ModernBertMLP {
             hidden_states.narrow(D::Minus1, self.intermediate_size, self.intermediate_size)?;
 
         let input = if let Some(activation) = &self.activation {
-            activation.forward(&input)?
+            activation.forward(&input)
         } else {
             Ok(input)
         };

--- a/backends/candle/src/models/modernbert.rs
+++ b/backends/candle/src/models/modernbert.rs
@@ -120,11 +120,7 @@ impl ModernBertMLP {
             hidden_states.narrow(D::Minus1, self.intermediate_size, self.intermediate_size)?;
 
         let input = if let Some(activation) = &self.activation {
-            match activation {
-                HiddenAct::Gelu => input.gelu(),
-                HiddenAct::Relu => input.relu(),
-                HiddenAct::Swiglu => input.silu(),
-            }
+            activation.forward(&input)?
         } else {
             Ok(input)
         };


### PR DESCRIPTION
# What does this PR do?

TL;DR Leverage `HiddenAct.forward` and handle SiLU and SwiGLU separately

This PR fixes the `forward` method in the `HiddenAct` implementation to use the SiLU activation when the activation is SwiGLU, since SwiGLU is SiLU + down projection to half the size since it's split on the intermediate dimension (as per https://github.com/huggingface/candle/blob/17313a4226a6c6bde444d28b4be4f0f96d155be7/candle-nn/src/ops.rs#L44-L47), and since `candle` brings an implementation for it, then the `serde` alias for `Silu` has been removed to handle separately both Silu and Swiglu.

Additionally, to unify the codebase, this PR leverages the `forward` method in `HiddenAct` instead of the previous `match self.act`.

Fixes #629

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [X] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@kozistr since they recently introduced the `forward` method in `HiddenAct` and @Narsil to verify the current patch