### PR TITLE
Remove default `--model-id` argument

### DIFF
--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -12,12 +12,14 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[derive(Parser, Redact)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// The name of the model to load.
-    /// Can be a MODEL_ID as listed on <https://hf.co/models> like
-    /// `BAAI/bge-large-en-v1.5`.
-    /// Or it can be a local directory containing the necessary files
-    /// as saved by `save_pretrained(...)` methods of transformers
-    #[clap(default_value = "BAAI/bge-large-en-v1.5", long, env)]
+    /// The Hugging Face model ID, can be any model listed on <https://huggingface.co/models> with
+    /// the `text-embeddings-inference` tag (meaning it's compatible with Text Embeddings
+    /// Inference)
+    ///
+    /// Alternatively, the specified ID can also be a path to a local directory containing the
+    /// necessary model files saved by the `save_pretrained(...)` methods of either Transformers or
+    /// Sentence Transformers.
+    #[clap(long, env)]
     #[redact(partial)]
     model_id: String,
 


### PR DESCRIPTION
# What does this PR do?

This PR removes the default value for the `--model-id` in the `clap` CLI i.e., the entrypoint for Text Embeddings Inference (TEI), to prevent cases where the model is not captured correctly from e.g. an environment variable, and the `BAAI/bge-large-en-v1.5` model is served instead without specific definition from the user, which can be misleading / confusing in some scenarios.

> [!NOTE]
> Since this PR represents somehow a "breaking change", the PR should be released within a minor version i.e., 1.8.0 if within the next release.

## What's missing?

- [ ] Once the PR is approved, update the `--help` outputs over the documentation and the `README.md` so that those are consistent with the latest CLI.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
[here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@Narsil