### PR TITLE
[Feature] Qwen3 Reranker

### DIFF
--- a/backends/candle/src/models/bert.rs
+++ b/backends/candle/src/models/bert.rs
@@ -597,6 +597,9 @@ impl BertModel {
                 };
                 (pool, None, splade)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`reranker` model type is not supported for Bert")
+            }
         };
 
         let (embeddings, encoder) = match (
@@ -615,7 +618,6 @@ impl BertModel {
                 }
             }
         };
-
         Ok(Self {
             embeddings,
             encoder,
@@ -660,6 +662,9 @@ impl BertModel {
                     None
                 };
                 (pool, None, splade)
+            }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`reranker` model type is not supported for RoBERTa")
             }
         };
 

--- a/backends/candle/src/models/distilbert.rs
+++ b/backends/candle/src/models/distilbert.rs
@@ -462,6 +462,9 @@ impl DistilBertModel {
 
                 (pool, None)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`reranker` model type is not supported for DistilBert")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/flash_bert.rs
+++ b/backends/candle/src/models/flash_bert.rs
@@ -259,6 +259,7 @@ impl FlashBertModel {
                 };
                 (pool, None, splade)
             }
+            ModelType::ListwiseReranker => todo!(),
         };
 
         let (embeddings, encoder) = match (
@@ -326,6 +327,7 @@ impl FlashBertModel {
                 };
                 (pool, None, splade)
             }
+            ModelType::ListwiseReranker => todo!(),
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/flash_distilbert.rs
+++ b/backends/candle/src/models/flash_distilbert.rs
@@ -200,6 +200,7 @@ impl FlashDistilBertModel {
                 candle::bail!("`classifier` model type is not supported for DistilBert")
             }
             ModelType::Embedding(pool) => pool,
+            ModelType::ListwiseReranker => todo!(),
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/flash_gte.rs
+++ b/backends/candle/src/models/flash_gte.rs
@@ -191,6 +191,7 @@ impl FlashGTEModel {
                 (pool, Some(classifier))
             }
             ModelType::Embedding(pool) => (pool, None),
+            ModelType::ListwiseReranker => todo!(),
         };
 
         let (word_embeddings, token_type_embeddings, layers, embeddings_norm) =

--- a/backends/candle/src/models/flash_jina.rs
+++ b/backends/candle/src/models/flash_jina.rs
@@ -267,6 +267,7 @@ impl FlashJinaBertModel {
                 }
                 (pool, None)
             }
+            ModelType::ListwiseReranker => todo!(),
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/flash_jina_code.rs
+++ b/backends/candle/src/models/flash_jina_code.rs
@@ -314,6 +314,7 @@ impl FlashJinaCodeBertModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => todo!(),
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/flash_mistral.rs
+++ b/backends/candle/src/models/flash_mistral.rs
@@ -251,6 +251,7 @@ impl FlashMistralModel {
                 candle::bail!("`classifier` model type is not supported for Mistral")
             }
             ModelType::Embedding(pool) => pool,
+            ModelType::ListwiseReranker => todo!(),
         };
 
         let embeddings = Embedding::new(

--- a/backends/candle/src/models/flash_modernbert.rs
+++ b/backends/candle/src/models/flash_modernbert.rs
@@ -274,6 +274,7 @@ impl FlashModernBertModel {
 
                 (pool, None)
             }
+            ModelType::ListwiseReranker => todo!(),
         };
 
         let embeddings = ModernBertEmbeddings::load(vb.pp("model.embeddings"), config)

--- a/backends/candle/src/models/flash_nomic.rs
+++ b/backends/candle/src/models/flash_nomic.rs
@@ -228,6 +228,7 @@ impl FlashNomicBertModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => todo!(),
         };
 
         let embeddings = NomicBertEmbeddings::load(vb.clone(), config)?;

--- a/backends/candle/src/models/flash_qwen2.rs
+++ b/backends/candle/src/models/flash_qwen2.rs
@@ -259,6 +259,7 @@ impl FlashQwen2Model {
                 candle::bail!("`classifier` model type is not supported for Qwen2")
             }
             ModelType::Embedding(pool) => pool,
+            ModelType::ListwiseReranker => todo!(),
         };
 
         // Pushing the prefix for `model` is apparently only required if the model architecture is

--- a/backends/candle/src/models/flash_qwen3.rs
+++ b/backends/candle/src/models/flash_qwen3.rs
@@ -281,6 +281,89 @@ impl Qwen3Layer {
     }
 }
 
+// Define ClassificationHead trait locally (following TEI pattern)
+trait ClassificationHead {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor>;
+}
+
+// Qwen3 Classification Head implementation
+#[derive(Debug)]
+struct Qwen3ClassificationHead {
+    dense: Linear,
+    out_proj: Linear,
+    activation: HiddenAct,
+    span: tracing::Span,
+}
+
+impl Qwen3ClassificationHead {
+    pub fn load(vb: VarBuilder, config: &Qwen3Config) -> Result<Self> {
+        let (dense, out_proj) = if vb.contains_tensor("score.dense.weight") {
+            tracing::info!("Loading Qwen3 classifier with score layers");
+
+            let dense_weight = vb
+                .pp("score.dense")
+                .get((config.hidden_size, config.hidden_size), "weight")?;
+            let dense_bias = vb.pp("score.dense").get(config.hidden_size, "bias")?;
+            let dense = Linear::new(dense_weight, Some(dense_bias), None);
+
+            let out_proj_weight = vb
+                .pp("score.out_proj")
+                .get((1, config.hidden_size), "weight")?;
+            let out_proj_bias = vb.pp("score.out_proj").get(1, "bias")?;
+            let out_proj = Linear::new(out_proj_weight, Some(out_proj_bias), None);
+
+            (dense, out_proj)
+        } else if vb.contains_tensor("classifier.dense.weight") {
+            tracing::info!("Loading Qwen3 classifier with classifier layers");
+
+            let dense_weight = vb
+                .pp("classifier.dense")
+                .get((config.hidden_size, config.hidden_size), "weight")?;
+            let dense_bias = vb.pp("classifier.dense").get(config.hidden_size, "bias")?;
+            let dense = Linear::new(dense_weight, Some(dense_bias), None);
+
+            let out_proj_weight = vb
+                .pp("classifier.out_proj")
+                .get((1, config.hidden_size), "weight")?;
+            let out_proj_bias = vb.pp("classifier.out_proj").get(1, "bias")?;
+            let out_proj = Linear::new(out_proj_weight, Some(out_proj_bias), None);
+
+            (dense, out_proj)
+        } else {
+            candle::bail!(
+                "Classification layers not found in model weights. \
+                Expected 'score.dense.weight' or 'classifier.dense.weight' for reranker models. \
+                This model may not be a trained reranker."
+            );
+        };
+
+        Ok(Self {
+            dense,
+            out_proj,
+            activation: config.hidden_act.clone(),
+            span: tracing::span!(tracing::Level::TRACE, "classifier"),
+        })
+    }
+}
+
+impl ClassificationHead for Qwen3ClassificationHead {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor> {
+        let _enter = self.span.enter();
+
+        // Input is already pooled
+
+        // Apply dense layer with activation
+        let hidden = self.dense.forward(hidden_states)?;
+        let hidden = self.activation.forward(&hidden)?;
+
+        // Project to single score
+        let score = self.out_proj.forward(&hidden)?;
+
+        // Squeeze to remove the last dimension if it's 1
+        score.squeeze(candle::D::Minus1)
+    }
+}
+
 pub struct FlashQwen3Model {
     embeddings: Embedding,
     layers: Vec<Qwen3Layer>,
@@ -288,6 +371,7 @@ pub struct FlashQwen3Model {
     cos_cache: Tensor,
     sin_cache: Tensor,
     pool: Pool,
+    classifier: Option<Box<dyn ClassificationHead + Send>>,
     pub device: Device,
 
     span: tracing::Span,
@@ -304,11 +388,19 @@ impl FlashQwen3Model {
             candle::bail!("FlashQwen3 requires DType::F16")
         }
 
-        let pool = match model_type {
+        let (pool, classifier) = match model_type {
             ModelType::Classifier => {
-                candle::bail!("`classifier` model type is not supported for Qwen3")
+                let pool = Pool::LastToken;
+                let classifier: Box<dyn ClassificationHead + Send> =
+                    Box::new(Qwen3ClassificationHead::load(vb.clone(), config)?);
+                (pool, Some(classifier))
             }
-            ModelType::Embedding(pool) => pool,
+            ModelType::Embedding(pool) => {
+                if pool == Pool::Splade {
+                    candle::bail!("`splade` is not supported for Qwen3")
+                }
+                (pool, None)
+            }
         };
 
         // The Qwen3-Reranker models contain the `model` key
@@ -351,6 +443,7 @@ impl FlashQwen3Model {
             cos_cache,
             sin_cache,
             pool,
+            classifier,
             device: vb.device().clone(),
             span: tracing::span!(tracing::Level::TRACE, "model"),
         })
@@ -511,5 +604,24 @@ impl Model for FlashQwen3Model {
 
     fn embed(&self, batch: Batch) -> Result<(Option<Tensor>, Option<Tensor>)> {
         self.forward(batch)
+    }
+
+    fn predict(&self, batch: Batch) -> Result<Tensor> {
+        match &self.classifier {
+            None => candle::bail!("`predict` is not implemented for this model"),
+            Some(classifier) => {
+                // Run forward pass to get hidden states
+                let (pooled_embeddings, _) = self.forward(batch)?;
+                match pooled_embeddings {
+                    Some(embeddings) => {
+                        let scores = classifier.forward(&embeddings)?;
+                        // Apply sigmoid to convert logits to probabilities
+                        let probabilities = candle_nn::ops::sigmoid(&scores)?;
+                        Ok(probabilities)
+                    }
+                    None => candle::bail!("No pooled embeddings returned for classification"),
+                }
+            }
+        }
     }
 }

--- a/backends/candle/src/models/gte.rs
+++ b/backends/candle/src/models/gte.rs
@@ -406,6 +406,9 @@ impl GTEModel {
                 (pool, Some(classifier))
             }
             ModelType::Embedding(pool) => (pool, None),
+            ModelType::ListwiseReranker => {
+                candle::bail!("`reranker` model type is not supported for GTE")
+            }
         };
 
         let (word_embeddings, token_type_embeddings, encoder, embeddings_norm) =

--- a/backends/candle/src/models/jina.rs
+++ b/backends/candle/src/models/jina.rs
@@ -436,6 +436,9 @@ impl JinaBertModel {
                 }
                 (pool, None)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`reranker` model type is not supported for Jina")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/jina_code.rs
+++ b/backends/candle/src/models/jina_code.rs
@@ -364,6 +364,9 @@ impl JinaCodeBertModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`reranker` model type is not supported for JinaCode")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/modernbert.rs
+++ b/backends/candle/src/models/modernbert.rs
@@ -498,6 +498,9 @@ impl ModernBertModel {
 
                 (pool, None)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`reranker` model type is not supported for ModernBert")
+            }
         };
 
         let embeddings = ModernBertEmbeddings::load(vb.pp("model.embeddings"), config)

--- a/backends/candle/src/models/mpnet.rs
+++ b/backends/candle/src/models/mpnet.rs
@@ -450,6 +450,9 @@ impl MPNetModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`reranker` model type is not supported for MPNet")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/nomic.rs
+++ b/backends/candle/src/models/nomic.rs
@@ -697,6 +697,9 @@ impl NomicBertModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`reranker` model type is not supported for Nomic")
+            }
         };
 
         let embeddings = NomicBertEmbeddings::load(vb.clone(), config)?;

--- a/backends/candle/tests/test_qwen3_reranker.rs
+++ b/backends/candle/tests/test_qwen3_reranker.rs
@@ -1,0 +1,145 @@
+mod common;
+
+use anyhow::Result;
+use common::{batch, download_artifacts, load_tokenizer};
+use text_embeddings_backend_candle::CandleBackend;
+use text_embeddings_backend_core::{Backend, ModelType};
+
+#[test]
+#[serial_test::serial]
+fn test_qwen3_reranker() -> Result<()> {
+    if std::env::var("SKIP_DOWNLOAD_TESTS").is_ok() {
+        return Ok(());
+    }
+
+    let model_root = download_artifacts("Qwen/Qwen3-Reranker-0.6B", None, None)?;
+    let tokenizer = load_tokenizer(&model_root)?;
+
+    let backend = CandleBackend::new(
+        &model_root,
+        "float32".to_string(),
+        ModelType::ListwiseReranker,
+        None,
+    )?;
+
+    let prefix = "<|im_start|>system\nJudge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\".<|im_end|>\n<|im_start|>user\n";
+    let suffix = "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n";
+    let instruct = "Given a web search query, retrieve relevant passages that answer the query";
+
+    let format_input = |query: &str, document: &str| -> String {
+        format!("{prefix}<Instruct>: {instruct}\n<Query>: {query}\n<Document>: {document}{suffix}")
+    };
+
+    let texts = [
+        format_input(
+            "What is the capital of China?",
+            "The capital of China is Beijing.",
+        ),
+        format_input(
+            "What is the capital of China?",
+            "The capital of France is Paris.",
+        ),
+        format_input(
+            "What is the capital of China?",
+            "China is a large country in Asia.",
+        ),
+    ];
+
+    let input_batch = batch(
+        texts
+            .iter()
+            .map(|t| tokenizer.encode(t.as_str(), true).unwrap())
+            .collect(),
+        vec![0, 1, 2],
+        vec![],
+    );
+
+    let predictions = backend.predict(input_batch)?;
+    let scores_vec: Vec<f32> = predictions.into_iter().flat_map(|(_, v)| v).collect();
+
+    assert_eq!(scores_vec.len(), 3, "Should return 3 scores for 3 inputs");
+
+    for (i, &score) in scores_vec.iter().enumerate() {
+        assert!(
+            score.is_finite() && (0.0..=1.0).contains(&score),
+            "Score[{}] = {} should be a valid probability",
+            i,
+            score
+        );
+    }
+
+    assert!(
+        scores_vec[0] > scores_vec[1],
+        "Beijing document (score={}) should score higher than Paris document (score={})",
+        scores_vec[0],
+        scores_vec[1]
+    );
+
+    assert!(
+        scores_vec[0] > scores_vec[2],
+        "Beijing document (score={}) should score higher than generic China document (score={})",
+        scores_vec[0],
+        scores_vec[2]
+    );
+
+    let single_text = format_input(
+        "What is machine learning?",
+        "Machine learning is a subset of artificial intelligence.",
+    );
+    let input_single = batch(
+        vec![tokenizer.encode(single_text.as_str(), true).unwrap()],
+        vec![0],
+        vec![],
+    );
+
+    let single_predictions = backend.predict(input_single)?;
+    let single_score_vec: Vec<f32> = single_predictions
+        .into_iter()
+        .flat_map(|(_, v)| v)
+        .collect();
+
+    assert_eq!(
+        single_score_vec.len(),
+        1,
+        "Should return 1 score for 1 input"
+    );
+    assert!(
+        single_score_vec[0].is_finite() && (0.0..=1.0).contains(&single_score_vec[0]),
+        "Single score should be a valid probability"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_qwen3_reranker_model_detection() {
+    // Test that model names containing "reranker" are properly detected
+    let reranker_models = vec![
+        "Qwen/Qwen3-Reranker-0.6B",
+        "Qwen/Qwen3-Reranker-4B",
+        "custom/qwen3-reranker-finetuned",
+        "org/model-qwen3-reranker",
+    ];
+
+    let non_reranker_models = vec![
+        "Qwen/Qwen3-0.5B",
+        "Qwen/Qwen3-7B-Instruct",
+        "Qwen/Qwen3-Embedding-0.6B",
+    ];
+
+    for model_name in reranker_models {
+        assert!(
+            model_name.to_lowercase().contains("reranker"),
+            "Model {} should be detected as reranker",
+            model_name
+        );
+    }
+
+    for model_name in non_reranker_models {
+        assert!(
+            !model_name.to_lowercase().contains("reranker"),
+            "Model {} should NOT be detected as reranker",
+            model_name
+        );
+    }
+}

--- a/backends/core/src/lib.rs
+++ b/backends/core/src/lib.rs
@@ -51,6 +51,7 @@ pub trait Backend {
 pub enum ModelType {
     Classifier,
     Embedding(Pool),
+    ListwiseReranker,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize)]

--- a/backends/ort/src/lib.rs
+++ b/backends/ort/src/lib.rs
@@ -38,6 +38,11 @@ impl OrtBackend {
                 }
                 pool => pool,
             },
+            ModelType::ListwiseReranker => {
+                return Err(BackendError::Start(
+                    "Reranker models are not supported in the ONNX backend".to_string(),
+                ));
+            }
         };
 
         // Get model path

--- a/backends/python/src/lib.rs
+++ b/backends/python/src/lib.rs
@@ -27,6 +27,7 @@ impl PythonBackend {
         let pool = match model_type {
             ModelType::Classifier => Pool::Cls,
             ModelType::Embedding(pool) => pool,
+            ModelType::ListwiseReranker => Pool::LastToken,
         };
 
         let backend_process = management::BackendProcess::new(

--- a/backends/src/dtype.rs
+++ b/backends/src/dtype.rs
@@ -7,30 +7,20 @@ use clap::ValueEnum;
 #[cfg_attr(feature = "clap", derive(Clone, ValueEnum))]
 pub enum DType {
     // Float16 is not available on accelerate
-    #[cfg(any(
-        feature = "python",
-        all(feature = "candle", not(feature = "accelerate"))
-    ))]
+    #[cfg(all(feature = "candle", not(feature = "accelerate")))]
     Float16,
-    #[cfg(any(feature = "python", feature = "candle", feature = "ort"))]
+    #[cfg(any(feature = "candle", feature = "ort"))]
     Float32,
-    #[cfg(feature = "python")]
-    Bfloat16,
 }
 
 impl fmt::Display for DType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             // Float16 is not available on accelerate
-            #[cfg(any(
-                feature = "python",
-                all(feature = "candle", not(feature = "accelerate"))
-            ))]
+            #[cfg(all(feature = "candle", not(feature = "accelerate")))]
             DType::Float16 => write!(f, "float16"),
-            #[cfg(any(feature = "python", feature = "candle", feature = "ort"))]
+            #[cfg(any(feature = "candle", feature = "ort"))]
             DType::Float32 => write!(f, "float32"),
-            #[cfg(feature = "python")]
-            DType::Bfloat16 => write!(f, "bfloat16"),
         }
     }
 }
@@ -42,18 +32,9 @@ impl Default for DType {
         {
             DType::Float32
         }
-        #[cfg(not(any(
-            feature = "accelerate",
-            feature = "mkl",
-            feature = "ort",
-            feature = "python"
-        )))]
+        #[cfg(not(any(feature = "accelerate", feature = "mkl", feature = "ort")))]
         {
             DType::Float16
-        }
-        #[cfg(feature = "python")]
-        {
-            DType::Bfloat16
         }
     }
 }

--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -179,7 +179,12 @@ impl Backend {
     }
 
     #[instrument(skip_all)]
-    pub fn create_warmup_batch(&self, shape: (u32, u32), max_token: u32, seq_bucket_size: u32) -> Batch {
+    pub fn create_warmup_batch(
+        &self,
+        shape: (u32, u32),
+        max_token: u32,
+        seq_bucket_size: u32,
+    ) -> Batch {
         let (batch_size, length) = shape;
         let min_length = length.saturating_sub(seq_bucket_size).saturating_add(1);
         let tmp_length = if min_length < length {

--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -170,7 +170,9 @@ impl Backend {
         for shape in shapes.iter() {
             let batch = self.create_warmup_batch(*shape, max_token as u32, seq_bucket_size as u32);
             match &self.model_type {
-                ModelType::Classifier => self.predict(batch).await.map(|_| ()),
+                ModelType::Classifier | ModelType::ListwiseReranker => {
+                    self.predict(batch).await.map(|_| ())
+                }
                 ModelType::Embedding(_) => self.embed(batch).await.map(|_| ()),
             }?;
             tracing::info!("finish warmup for batch: {}, length: {}", shape.0, shape.1);
@@ -280,7 +282,9 @@ impl Backend {
         };
 
         match &self.model_type {
-            ModelType::Classifier => self.predict(batch).await.map(|_| ()),
+            ModelType::Classifier | ModelType::ListwiseReranker => {
+                self.predict(batch).await.map(|_| ())
+            }
             ModelType::Embedding(_) => self.embed(batch).await.map(|_| ()),
         }
     }
@@ -313,7 +317,9 @@ impl Backend {
                 raw_indices: vec![],
             };
             match &self.model_type {
-                ModelType::Classifier => self.predict(batch).await.map(|_| ()),
+                ModelType::Classifier | ModelType::ListwiseReranker => {
+                    self.predict(batch).await.map(|_| ())
+                }
                 ModelType::Embedding(_) => self.embed(batch).await.map(|_| ()),
             }
         }

--- a/core/src/infer.rs
+++ b/core/src/infer.rs
@@ -499,7 +499,10 @@ impl Infer {
 
     #[instrument(skip(self))]
     pub fn is_classifier(&self) -> bool {
-        matches!(self.backend.model_type, ModelType::Classifier)
+        matches!(
+            self.backend.model_type,
+            ModelType::Classifier | ModelType::ListwiseReranker
+        )
     }
 
     #[instrument(skip(self))]

--- a/core/src/infer.rs
+++ b/core/src/infer.rs
@@ -547,7 +547,7 @@ async fn batching_task(queue: Queue, notify: Arc<Notify>, embed_sender: mpsc::Se
 async fn backend_task(backend: Backend, mut embed_receiver: mpsc::Receiver<NextBatch>) {
     while let Some(batch) = embed_receiver.recv().await {
         match &backend.model_type {
-            ModelType::Classifier => {
+            ModelType::Classifier | ModelType::ListwiseReranker => {
                 let results = backend.predict(batch.1).await;
 
                 // Handle sending responses in another thread to avoid starving the backend

--- a/router/Cargo.toml
+++ b/router/Cargo.toml
@@ -85,7 +85,6 @@ grpc = ["metrics-exporter-prometheus/http-listener", "dep:prost", "dep:tonic", "
 metal = ["text-embeddings-backend/metal"]
 mkl = ["text-embeddings-backend/mkl"]
 accelerate = ["text-embeddings-backend/accelerate"]
-python = ["text-embeddings-backend/python"]
 ort = ["text-embeddings-backend/ort"]
 candle = ["text-embeddings-backend/candle"]
 candle-cuda = ["candle", "text-embeddings-backend/flash-attn", "dep:cudarc"]

--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -138,7 +138,7 @@ async fn predict(
 
         let id2label = match &info.model_type {
             ModelType::Classifier(classifier) => &classifier.id2label,
-            ModelType::Reranker(classifier) => &classifier.id2label,
+            ModelType::ListwiseReranker(classifier) => &classifier.id2label,
             _ => panic!(),
         };
 
@@ -330,7 +330,7 @@ async fn rerank(
     }
 
     match &info.model_type {
-        ModelType::Reranker(_) => Ok(()),
+        ModelType::ListwiseReranker(_) => Ok(()),
         ModelType::Classifier(_) | ModelType::Embedding(_) => {
             let counter = metrics::counter!("te_request_failure", "err" => "model_type");
             counter.increment(1);
@@ -1551,7 +1551,7 @@ async fn vertex_compatibility(
         }
 
         match info.model_type {
-            ModelType::Classifier(_) | ModelType::Reranker(_) => {
+            ModelType::Classifier(_) | ModelType::ListwiseReranker(_) => {
                 let instance = serde_json::from_value::<PredictRequest>(instance)
                     .map_err(ErrorResponse::from)?;
                 futures
@@ -1782,7 +1782,7 @@ pub async fn run(
                     // AWS Sagemaker route
                     .route("/invocations", post(predict))
             }
-            ModelType::Reranker(_) => {
+            ModelType::ListwiseReranker(_) => {
                 routes
                     .route("/", post(rerank))
                     // AWS Sagemaker route

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -26,6 +26,7 @@ use std::fs;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
 use std::time::{Duration, Instant};
+use serde_json::json;
 use text_embeddings_backend::{DType, Pool};
 use text_embeddings_core::download::{download_artifacts, ST_CONFIG_NAMES};
 use text_embeddings_core::infer::Infer;
@@ -240,6 +241,7 @@ pub async fn run(
         position_offset,
         default_prompt,
         prompts,
+        backend_model_type.clone(),
     );
 
     // Get dtype
@@ -418,6 +420,13 @@ fn get_backend_model_type(
             return Ok(text_embeddings_backend::ModelType::Embedding(
                 text_embeddings_backend::Pool::Splade,
             ));
+        } else if arch == "Qwen3ForSequenceClassification" {
+            if pooling.is_some() {
+                tracing::warn!(
+                    "`--pooling` arg is set but model is a reranker. Ignoring `--pooling` arg."
+                );
+            }
+            return Ok(text_embeddings_backend::ModelType::ListwiseReranker);
         } else if arch.ends_with("Classification") {
             if pooling.is_some() {
                 tracing::warn!(


### PR DESCRIPTION
## What does this PR do?

This PR adds support for Qwen3 reranker models to `text-embeddings-inference`. (Issue: https://github.com/huggingface/text-embeddings-inference/issues/643)

These models function as binary classifiers that determine the relevance between a query and a document. They output a simple probability score, making them perfect for re-ranking search results.

## Key Changes

  *  Introduced a new `ListwiseReranker` model type to properly distinguish these models from standard cross-encoder models.
  * Enabled reranker functionality for both the standard and Flash Qwen3 models. This involved:
      * Implementing a `predict` method to extract the logits for "yes" and "no" tokens.
      * Calculating the final score based on the probability of the "yes" token.
  * The router now automatically identifies reranker models by checking if "reranker" is in the model name or if the `is_reranker` flag is set in the model's config.

## Technical Details

  * The models use the hidden state of the final token to predict relevance.
  * Scores are calculated from the logits for the "yes" (ID: `9693`) and "no" (ID: `2152`) tokens.
  * The final output is a probability score between 0 and 1, representing how relevant a document is to the query.

## Who can review?

Anyone in the community is welcome to review the PR once the tests have passed. Feel free to tag anyone who might be interested.

@OlivierDehaene or @Narsil