### PR TITLE
Add support for `position_ids` and `past_key_values` in `OrtBackend`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +936,16 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -1753,7 +1769,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "ureq",
+ "ureq 2.12.1",
  "windows-sys 0.59.0",
 ]
 
@@ -1874,7 +1890,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "smallvec",
+ "smallvec 1.15.0",
  "tokio",
  "want",
 ]
@@ -2027,7 +2043,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec",
+ "smallvec 1.15.0",
  "utf16_iter",
  "utf8_iter",
  "write16",
@@ -2102,7 +2118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
  "idna_adapter",
- "smallvec",
+ "smallvec 1.15.0",
  "utf8_iter",
 ]
 
@@ -2855,7 +2871,7 @@ dependencies = [
  "tar",
  "thiserror 1.0.69",
  "toml",
- "ureq",
+ "ureq 2.12.1",
  "url",
  "uuid",
  "walkdir",
@@ -3136,27 +3152,28 @@ dependencies = [
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
+checksum = "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721"
 dependencies = [
  "half",
  "ndarray",
  "ort-sys",
+ "smallvec 2.0.0-alpha.10",
  "tracing",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
+checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
 dependencies = [
  "flate2",
  "pkg-config",
  "sha2",
  "tar",
- "ureq",
+ "ureq 3.0.12",
 ]
 
 [[package]]
@@ -3190,7 +3207,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.15.0",
  "windows-targets 0.52.6",
 ]
 
@@ -3199,6 +3216,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4252,6 +4278,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "smallvec"
+version = "2.0.0-alpha.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
+
+[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4507,6 +4539,7 @@ dependencies = [
  "nohash-hasher",
  "num_cpus",
  "ort",
+ "ort-sys",
  "serde",
  "serde_json",
  "text-embeddings-backend-core",
@@ -5101,7 +5134,7 @@ dependencies = [
  "once_cell",
  "opentelemetry 0.22.0",
  "opentelemetry_sdk 0.22.1",
- "smallvec",
+ "smallvec 1.15.0",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
@@ -5119,7 +5152,7 @@ dependencies = [
  "once_cell",
  "opentelemetry 0.23.0",
  "opentelemetry_sdk 0.23.0",
- "smallvec",
+ "smallvec 1.15.0",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
@@ -5162,7 +5195,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.15.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -5248,7 +5281,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
- "smallvec",
+ "smallvec 1.15.0",
 ]
 
 [[package]]
@@ -5301,6 +5334,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ureq"
+version = "3.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
+dependencies = [
+ "base64 0.22.1",
+ "der",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "socks",
+ "ureq-proto",
+ "utf-8",
+ "webpki-root-certs 0.26.11",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5316,6 +5380,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -5581,6 +5651,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.2",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4ffd8df1c57e87c325000a3d6ef93db75279dc3a231125aac571650f22b12a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/backends/ort/Cargo.toml
+++ b/backends/ort/Cargo.toml
@@ -10,7 +10,8 @@ anyhow = { workspace = true }
 nohash-hasher = { workspace = true }
 ndarray = "0.16.1"
 num_cpus = { workspace = true }
-ort = { version = "2.0.0-rc.8", default-features = false, features = ["download-binaries", "half", "onednn", "ndarray"] }
+ort = { version = "2.0.0-rc.10", default-features = false, features = ["std", "download-binaries", "half", "onednn", "ndarray"] }
+ort-sys = { version = "=2.0.0-rc.10", default-features = false }  # https://github.com/pykeio/ort/issues/399
 text-embeddings-backend-core = { path = "../core" }
 tracing = { workspace = true }
 thiserror = { workspace = true }

--- a/backends/ort/src/lib.rs
+++ b/backends/ort/src/lib.rs
@@ -1,6 +1,7 @@
 use ndarray::{s, Axis};
 use nohash_hasher::BuildNoHashHasher;
 use ort::session::{builder::GraphOptimizationLevel, Session};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::ops::{Div, Mul};
 use std::path::Path;
@@ -8,10 +9,31 @@ use text_embeddings_backend_core::{
     Backend, BackendError, Batch, Embedding, Embeddings, ModelType, Pool, Predictions,
 };
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_key_value_heads: usize,
+    #[allow(unused)]
+    pub eos_token_id: Option<usize>,
+    #[allow(unused)]
+    pub pad_token_id: Option<usize>,
+}
+
 pub struct OrtBackend {
     session: Session,
+    // NOTE: only required for handling the `past_key_values` parsing, and eventually for re-using
+    // the EOS and PAD tokens if needed
+    config: ModelConfig,
+
+    token_type_ids: bool,
+    // NOTE: required since the key can either be `token_type_ids` or `input_type`
+    token_type_ids_key: String,
+    position_ids: bool,
+    past_key_values: bool,
+
     pool: Pool,
-    type_id_name: Option<String>,
 }
 
 impl OrtBackend {
@@ -20,27 +42,24 @@ impl OrtBackend {
         dtype: String,
         model_type: ModelType,
     ) -> Result<Self, BackendError> {
-        // Check dtype
         if dtype != "float32" {
             return Err(BackendError::Start(format!(
-                "DType {dtype} is not supported"
+                "Dtype {dtype} is not supported for `ort`, only float32."
             )));
         };
 
-        // Check model type
         let pool = match model_type {
             ModelType::Classifier => Pool::Cls,
             ModelType::Embedding(pool) => match pool {
                 Pool::Splade => {
                     return Err(BackendError::Start(format!(
-                        "Pooling {pool} is not supported for this backend. Use `candle` backend instead."
+                        "Pooling {pool} is not supported for `ort`, use `candle` instead."
                     )));
                 }
-                pool => pool,
+                _ => pool,
             },
         };
 
-        // Get model path
         let onnx_path = {
             let default_path = model_path.join("model.onnx");
             match default_path.exists() {
@@ -49,7 +68,20 @@ impl OrtBackend {
             }
         };
 
-        // Start onnx session
+        let config = {
+            let config_path = model_path.join("config.json");
+            if !config_path.exists() {
+                return Err(BackendError::Start(format!(
+                    "config.json not found at {:?}",
+                    config_path
+                )));
+            }
+            let config_content = std::fs::read_to_string(config_path)
+                .map_err(|e| BackendError::Start(format!("Failed to read config.json: {}", e)))?;
+            serde_json::from_str::<ModelConfig>(&config_content)
+                .map_err(|e| BackendError::Start(format!("Failed to parse config.json: {}", e)))?
+        };
+
         let session = Session::builder()
             .s()?
             .with_intra_threads(num_cpus::get())
@@ -59,19 +91,37 @@ impl OrtBackend {
             .commit_from_file(onnx_path)
             .s()?;
 
-        // Check if the model requires type tokens
-        let mut type_id_name = None;
+        let mut token_type_ids = false;
+        let mut token_type_ids_key = String::from("token_type_ids");
+        let mut position_ids = false;
+        let mut past_key_values = false;
+
         for input in &session.inputs {
-            if &input.name == "token_type_ids" || &input.name == "input_type" {
-                type_id_name = Some(input.name.clone());
-                break;
+            match input.name.as_str() {
+                "token_type_ids" | "input_type" => {
+                    token_type_ids = true;
+                    token_type_ids_key = String::from("token_type_ids");
+                }
+                "position_ids" => {
+                    position_ids = true;
+                }
+                name if name.starts_with("past_key_values.") => {
+                    past_key_values = true;
+                }
+                // NOTE: no need to handle `inputs_ids` and `attention_mask` since those are always
+                // required
+                _ => {}
             }
         }
 
         Ok(Self {
             session,
+            config,
+            token_type_ids,
+            token_type_ids_key,
+            position_ids,
+            past_key_values,
             pool,
-            type_id_name,
         })
     }
 }
@@ -96,14 +146,15 @@ impl Backend for OrtBackend {
         // Whether a least one of the request in the batch is padded
         let mut masking = false;
 
-        let (input_ids, type_ids, input_lengths, attention_mask) = {
+        let (input_ids, token_type_ids, input_lengths, attention_mask, position_ids) = {
             let elems = batch_size * max_length;
 
             if batch_size > 1 {
                 // Prepare padded batch
                 let mut input_ids = Vec::with_capacity(elems);
-                let mut type_ids = Vec::with_capacity(elems);
+                let mut token_type_ids = Vec::with_capacity(elems);
                 let mut attention_mask = Vec::with_capacity(elems);
+                let mut position_ids = Vec::with_capacity(elems);
                 let mut input_lengths = Vec::with_capacity(batch_size);
 
                 for i in 0..batch_size {
@@ -113,10 +164,11 @@ impl Backend for OrtBackend {
                     input_lengths.push(seq_length as f32);
 
                     // Copy values
-                    for j in start..end {
+                    for (pos, j) in (start..end).enumerate() {
                         input_ids.push(batch.input_ids[j] as i64);
-                        type_ids.push(batch.token_type_ids[j] as i64);
+                        token_type_ids.push(batch.token_type_ids[j] as i64);
                         attention_mask.push(1_i64);
+                        position_ids.push(pos as i64);
                     }
 
                     // Add padding if needed
@@ -124,22 +176,31 @@ impl Backend for OrtBackend {
                     if padding > 0 {
                         // Set bool to use attention mask
                         masking = true;
-                        for _ in 0..padding {
+                        for pad_pos in 0..padding {
                             input_ids.push(0);
-                            type_ids.push(0);
+                            token_type_ids.push(0);
                             attention_mask.push(0_i64);
+                            position_ids.push((seq_length + pad_pos) as i64);
                         }
                     }
                 }
-                (input_ids, type_ids, input_lengths, attention_mask)
+                (
+                    input_ids,
+                    token_type_ids,
+                    input_lengths,
+                    attention_mask,
+                    position_ids,
+                )
             } else {
                 let attention_mask = vec![1_i64; elems];
+                let position_ids: Vec<i64> = (0..max_length as i64).collect();
 
                 (
                     batch.input_ids.into_iter().map(|v| v as i64).collect(),
                     batch.token_type_ids.into_iter().map(|v| v as i64).collect(),
                     vec![batch.max_length as f32],
                     attention_mask,
+                    position_ids,
                 )
             }
         };
@@ -148,20 +209,58 @@ impl Backend for OrtBackend {
         let input_ids = ndarray::Array2::from_shape_vec((batch_size, max_length), input_ids).e()?;
         let attention_mask =
             ndarray::Array2::from_shape_vec((batch_size, max_length), attention_mask).e()?;
+        let position_ids =
+            ndarray::Array2::from_shape_vec((batch_size, max_length), position_ids).e()?;
         let input_lengths = ndarray::Array1::from_vec(input_lengths);
 
-        // Create onnx inputs
-        let inputs = match self.type_id_name.as_ref() {
-            Some(type_id_name) => {
-                // Add type ids to inputs
-                let type_ids =
-                    ndarray::Array2::from_shape_vec((batch_size, max_length), type_ids).e()?;
-                ort::inputs!["input_ids" => input_ids, "attention_mask" => attention_mask.clone(), type_id_name => type_ids].e()?
+        let inputs = {
+            let mut inputs = ort::inputs![
+                "input_ids" => input_ids,
+                "attention_mask" => attention_mask.clone(),
+            ]
+            .e()?;
+
+            if self.token_type_ids {
+                let token_type_ids_tensor =
+                    ndarray::Array2::from_shape_vec((batch_size, max_length), token_type_ids)
+                        .e()?;
+                let token_type_ids_value =
+                    ort::value::Value::from_array(token_type_ids_tensor).e()?;
+                inputs.push((
+                    self.token_type_ids_key.clone().into(),
+                    token_type_ids_value.into(),
+                ));
             }
-            None => {
-                ort::inputs!["input_ids" => input_ids, "attention_mask" => attention_mask.clone()]
-                    .e()?
+
+            if self.position_ids {
+                let position_ids_value = ort::value::Value::from_array(position_ids).e()?;
+                inputs.push(("position_ids".into(), position_ids_value.into()));
             }
+
+            if self.past_key_values {
+                let head_size = self.config.hidden_size / self.config.num_key_value_heads;
+
+                for i in 0..self.config.num_hidden_layers {
+                    let key_shape = (batch_size, self.config.num_key_value_heads, 0, head_size);
+                    let value_shape = (batch_size, self.config.num_key_value_heads, 0, head_size);
+
+                    let empty_key = ndarray::Array4::<f32>::zeros(key_shape);
+                    let empty_value = ndarray::Array4::<f32>::zeros(value_shape);
+
+                    let key_value = ort::value::Value::from_array(empty_key).e()?;
+                    let value_value = ort::value::Value::from_array(empty_value).e()?;
+                    inputs.push((
+                        format!("past_key_values.{}.key", i).into(),
+                        key_value.into(),
+                    ));
+                    inputs.push((
+                        format!("past_key_values.{}.value", i).into(),
+                        value_value.into(),
+                    ));
+                }
+            }
+
+            inputs
         };
 
         // Run model
@@ -202,7 +301,6 @@ impl Backend for OrtBackend {
             };
 
             let pooled_embeddings = match self.pool {
-                // CLS pooling
                 Pool::Cls => outputs.slice(s![.., 0, ..]).into_owned().into_dyn(),
                 Pool::LastToken => {
                     let axis_len = outputs.len_of(Axis(1));
@@ -211,7 +309,6 @@ impl Backend for OrtBackend {
                         .into_owned()
                         .into_dyn()
                 }
-                // Mean pooling
                 Pool::Mean => {
                     if masking {
                         let mut attention_mask = attention_mask;
@@ -302,14 +399,15 @@ impl Backend for OrtBackend {
         let batch_size = batch.len();
         let max_length = batch.max_length as usize;
 
-        let (input_ids, type_ids, attention_mask) = {
+        let (input_ids, token_type_ids, attention_mask, position_ids) = {
             let elems = batch_size * max_length;
 
             if batch_size > 1 {
                 // Prepare padded batch
                 let mut input_ids = Vec::with_capacity(elems);
-                let mut type_ids = Vec::with_capacity(elems);
+                let mut token_type_ids = Vec::with_capacity(elems);
                 let mut attention_mask = Vec::with_capacity(elems);
+                let mut position_ids = Vec::with_capacity(elems);
 
                 for i in 0..batch_size {
                     let start = batch.cumulative_seq_lengths[i] as usize;
@@ -317,30 +415,34 @@ impl Backend for OrtBackend {
                     let seq_length = (end - start) as u32;
 
                     // Copy values
-                    for j in start..end {
+                    for (pos, j) in (start..end).enumerate() {
                         input_ids.push(batch.input_ids[j] as i64);
-                        type_ids.push(batch.token_type_ids[j] as i64);
+                        token_type_ids.push(batch.token_type_ids[j] as i64);
                         attention_mask.push(1_i64);
+                        position_ids.push(pos as i64);
                     }
 
                     // Add padding if needed
                     let padding = batch.max_length - seq_length;
                     if padding > 0 {
-                        for _ in 0..padding {
+                        for pad_pos in 0..padding {
                             input_ids.push(0);
-                            type_ids.push(0);
+                            token_type_ids.push(0);
                             attention_mask.push(0_i64);
+                            position_ids.push((seq_length + pad_pos) as i64);
                         }
                     }
                 }
-                (input_ids, type_ids, attention_mask)
+                (input_ids, token_type_ids, attention_mask, position_ids)
             } else {
                 let attention_mask = vec![1_i64; elems];
+                let position_ids: Vec<i64> = (0..max_length as i64).collect();
 
                 (
                     batch.input_ids.into_iter().map(|v| v as i64).collect(),
                     batch.token_type_ids.into_iter().map(|v| v as i64).collect(),
                     attention_mask,
+                    position_ids,
                 )
             }
         };
@@ -349,19 +451,57 @@ impl Backend for OrtBackend {
         let input_ids = ndarray::Array2::from_shape_vec((batch_size, max_length), input_ids).e()?;
         let attention_mask =
             ndarray::Array2::from_shape_vec((batch_size, max_length), attention_mask).e()?;
+        let position_ids =
+            ndarray::Array2::from_shape_vec((batch_size, max_length), position_ids).e()?;
 
-        // Create onnx inputs
-        let inputs = match self.type_id_name.as_ref() {
-            Some(type_id_name) => {
-                // Add type ids to inputs
-                let type_ids =
-                    ndarray::Array2::from_shape_vec((batch_size, max_length), type_ids).e()?;
-                ort::inputs!["input_ids" => input_ids, "attention_mask" => attention_mask.clone(), type_id_name => type_ids].e()?
+        let inputs = {
+            let mut inputs = ort::inputs![
+                "input_ids" => input_ids,
+                "attention_mask" => attention_mask.clone(),
+            ]
+            .e()?;
+
+            if self.token_type_ids {
+                let token_type_ids_tensor =
+                    ndarray::Array2::from_shape_vec((batch_size, max_length), token_type_ids)
+                        .e()?;
+                let token_type_ids_value =
+                    ort::value::Value::from_array(token_type_ids_tensor).e()?;
+                inputs.push((
+                    self.token_type_ids_key.clone().into(),
+                    token_type_ids_value.into(),
+                ));
             }
-            None => {
-                ort::inputs!["input_ids" => input_ids, "attention_mask" => attention_mask.clone()]
-                    .e()?
+
+            if self.position_ids {
+                let position_ids_value = ort::value::Value::from_array(position_ids).e()?;
+                inputs.push(("position_ids".into(), position_ids_value.into()));
             }
+
+            if self.past_key_values {
+                let head_size = self.config.hidden_size / self.config.num_key_value_heads;
+
+                for i in 0..self.config.num_hidden_layers {
+                    let key_shape = (batch_size, self.config.num_key_value_heads, 0, head_size);
+                    let value_shape = (batch_size, self.config.num_key_value_heads, 0, head_size);
+
+                    let empty_key = ndarray::Array4::<f32>::zeros(key_shape);
+                    let empty_value = ndarray::Array4::<f32>::zeros(value_shape);
+
+                    let key_value = ort::value::Value::from_array(empty_key).e()?;
+                    let value_value = ort::value::Value::from_array(empty_value).e()?;
+                    inputs.push((
+                        format!("past_key_values.{}.key", i).into(),
+                        key_value.into(),
+                    ));
+                    inputs.push((
+                        format!("past_key_values.{}.value", i).into(),
+                        value_value.into(),
+                    ));
+                }
+            }
+
+            inputs
         };
 
         // Run model

--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -179,7 +179,12 @@ impl Backend {
     }
 
     #[instrument(skip_all)]
-    pub fn create_warmup_batch(&self, shape: (u32, u32), max_token: u32, seq_bucket_size: u32) -> Batch {
+    pub fn create_warmup_batch(
+        &self,
+        shape: (u32, u32),
+        max_token: u32,
+        seq_bucket_size: u32,
+    ) -> Batch {
         let (batch_size, length) = shape;
         let min_length = length.saturating_sub(seq_bucket_size).saturating_add(1);
         let tmp_length = if min_length < length {


### PR DESCRIPTION
# What does this PR do?

This PR updates how the `ort` inputs are being handled to extend support for optional values such as `position_ids` or `past_key_values`.

e.g. `onnx-community/Qwen3-Embedding-0.6B-ONNX` has been now enabled on Text Embeddings Inference (TEI) via `ort` thanks to the conditional addition of the `past_key_values` if amongst the inputs, to leverage the optimized Multi-head Attention (MHA) nodes that do require those inputs, so now one could run the following (whereas with the version in `main` it would fail with missing inputs on `past_key_values`):

```bash
cargo run --release --features ort,http --no-default-features -- --model-id onnx-community/Qwen3-Embedding-0.6B-ONNX --dtype float32 --pooling last-token
```

> [!NOTE]
> On a subsequent PR, both the input building and the pooling strategies for ONNX need to be updated to use the correct padding side, as it defaults to right padding which tends to be the norm, but there are models such as e.g. https://huggingface.co/onnx-community/Qwen3-Embedding-0.6B-ONNX, that use left padding instead.

---

Besides that this PR also bumps `ort` to the latest release candidate whilst v2.0.0 is released, with the following breaking changes:

- `ort::session::Session` is now mutable, so placed in a `Mutex`
- `try_extract_tensor` is now `try_extract_array`
- `ort::inputs!` won't accept the `ndarray`, but rather an `ort::value`
e.g. `ort::value::Tensor`

Additionally, it requires to pin `ort-sys` and add the `std` feature to `ort`. More information in the release notes at https://github.com/pykeio/ort/releases/tag/v2.0.0-rc.10.

> [!WARNING]
> As per the breaking changes above, and considering that the `ort` release is just a release candidate and not a stable version, that will most likely not land yet on Text Embeddings Inference (TEI), but still leaving the history in the PR just in case.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil