### PR TITLE
Add `padding_side` handling in `OrtBackend`

### DIFF
--- a/backends/ort/src/lib.rs
+++ b/backends/ort/src/lib.rs
@@ -47,6 +47,7 @@ pub struct OrtBackend {
 
     pool: Pool,
     padding_side: PaddingSide,
+    pad_token_id: usize,
 }
 
 impl OrtBackend {
@@ -163,6 +164,7 @@ impl OrtBackend {
             past_key_values_config,
             pool,
             padding_side,
+            pad_token_id: 0,
         })
     }
 }

--- a/backends/ort/src/lib.rs
+++ b/backends/ort/src/lib.rs
@@ -178,12 +178,12 @@ impl OrtBackend {
                     .get("padding_side")?
                     .as_str()?
                     .parse::<PaddingSide>()
-                    .map_err(|e| tracing::warn!("Failed to parse `padding_side` from `tokenizer_config.json`: {}, hence using 'right' padding by default.", e))
+                    .map_err(|e| tracing::warn!("Failed to parse `padding_side` from `tokenizer_config.json`: {}, hence using `right` padding by default.", e))
                     .ok()
             })
             .flatten()
             .unwrap_or_else(|| {
-                tracing::warn!("Could not determine `padding_side` from `tokenizer_config.json`, hence using 'right' padding by default.");
+                tracing::warn!("Could not determine `padding_side` from `tokenizer_config.json`, hence using `right` padding by default.");
                 PaddingSide::Right
             });
 
@@ -501,6 +501,9 @@ impl Backend for OrtBackend {
                     PaddingSide::Right => outputs.slice(s![.., 0, ..]).into_owned().into_dyn(),
                 },
                 Pool::LastToken => match self.padding_side {
+                    // NOTE: when using left-padding, the last-token is always in the last position
+                    // as the padding tokens are on the left (note that given that the last token
+                    // in the sequence is the EOS token we need to use the last - 1.
                     PaddingSide::Left => {
                         let axis_len = outputs.len_of(Axis(1));
                         outputs

--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -380,6 +380,18 @@ async fn init_backend(
                 }
             }
 
+            // NOTE: for ONNX we need to retrieve the `tokenizer_config.json` to identify which
+            // `padding_side` needs to be applied for the input processing and the pooling
+            if let Some(api_repo) = api_repo.as_ref() {
+                tracing::info!("Downloading `tokenizer_config.json`");
+                match api_repo.get("tokenizer_config.json").await {
+                    Ok(_) => (),
+                    Err(err) => {
+                        tracing::warn!("Could not download `tokenizer_config.json`: {}", err)
+                    }
+                }
+            }
+
             let backend = OrtBackend::new(&model_path, dtype.to_string(), model_type.clone());
             match backend {
                 Ok(b) => return Ok(Box::new(b)),


### PR DESCRIPTION
# What does this PR do?

This PR adds the `padding_side` from the `tokenizer_config.json` if applicable, otherwise it defaults to `padding_side: "right"` to handle the scenarios where the `padding_side` is other than "right", as e.g. https://huggingface.co/onnx-community/Qwen3-Embedding-0.6B-ONNX to ensure parity with the inputs and the outputs.

This PR also updates the input preparation and pooling strategies accordingly, so that those are applied one way or another based on the padding side, given that the pooling should be padding-agnostic, but with the padding side information we can efficiently apply the pooling strategies instead.

Additionally, this PR fixes the last-token pooling for the `OrtBackend` which was leading to issues (unrelated to the `padding_side`) as e.g. https://github.com/huggingface/text-embeddings-inference/issues/704

As some other, smaller but still relevant changes, this PR:
- Adds `OrtBackend::prepare_inputs` to prepare the `ndarray`s for the `input_ids`, `attention_mask`, etc. within a function to be reused for both `OrtBackend::embed` and `OrtBackend::predict` to prevent from duplicating the code
- Adds `OrtBackend::prepare_ort_inputs` to go from `ndarray`s to `ort::inputs!`, and the reason is the same as per the function above.
- Adds `ModelInputs` to capture all the inputs within the same struct so that it can be easily managed
- Adds `Config` to handle also the `pad_token_id`, because it was previously set as 0 whilst that was not true for all the models, so now the `pad_token_id` is read from the `config.json` if there, otherwise it falls back to `eos_token_id`, or alternatively sets it to 0.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil