### PR TITLE
Fix `cargo install` commands for `candle` with CUDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,13 +530,13 @@ export PATH=$PATH:/usr/local/cuda/bin
 Then run:
 
 ```shell
-# This can take a while as we need to compile a lot of cuda kernels
+# This can take a while as we need to compile a lot of CUDA kernels
 
 # On Turing GPUs (T4, RTX 2000 series ... )
-cargo install --path router -F candle-cuda-turing -F http --no-default-features
+cargo install --path router -F candle-cuda-turing
 
 # On Ampere and Hopper
-cargo install --path router -F candle-cuda -F http --no-default-features
+cargo install --path router -F candle-cuda
 ```
 
 You can now launch Text Embeddings Inference on GPU with:

--- a/docs/source/en/local_gpu.md
+++ b/docs/source/en/local_gpu.md
@@ -39,18 +39,18 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 ## Step 3: Install necessary packages
 
-This step  can take a while as we need to compile a lot of cuda kernels.
+This step  can take a while as we need to compile a lot of CUDA kernels.
 
 ### For Turing GPUs (T4, RTX 2000 series ... )
 
 ```shell
-cargo install --path router -F candle-cuda-turing -F http --no-default-features
+cargo install --path router -F candle-cuda-turing
 ```
 
 ### For Ampere and Hopper
 
 ```shell
-cargo install --path router -F candle-cuda -F http --no-default-features
+cargo install --path router -F candle-cuda
 ```
 
 ## Step 4: Launch Text Embeddings Inference


### PR DESCRIPTION
# What does this PR do?

This PR fixes the `cargo install --path router ...` commands in both `README.md` and `docs/source/en/local_gpu.md` for the features `candle-cuda` and `candle-cuda-turing`, as those were using the flag `--no-default-features` that was ignoring the default features in the `text-embeddings-router` being `candle,http,dynamic-linking`, hence the command was failing as `cudarc` requires to have any linking out of `static-linking`, `dynamic-linking` or `dynamic-loading` for the CUDA Libraries.

Fixes #709 

## Before submitting

- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [X] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@Narsil