### PR TITLE
Fix OpenAI client usage example for embeddings

### DIFF
--- a/docs/source/en/quick_tour.md
+++ b/docs/source/en/quick_tour.md
@@ -94,18 +94,6 @@ print(response.data[0].embedding)
 ```
 
 Alternatively, you can also send the request with cURL as follows:
-
-```bash
-curl http://localhost/v1/embeddings \
-  -H "Content-Type: application/json" \
-  -d '{
-    "input": "What is Deep Learning?",
-    "model": "text-embeddings-inference",
-    "encoding_format": "float"
-  }'
-``
-
-Alternatively, you can also send the request with cURL as follows:
 ```bash
 curl http://localhost:8080/v1/embeddings \
   -H "Content-Type: application/json" \

--- a/docs/source/en/quick_tour.md
+++ b/docs/source/en/quick_tour.md
@@ -94,6 +94,18 @@ print(response.data[0].embedding)
 ```
 
 Alternatively, you can also send the request with cURL as follows:
+
+```bash
+curl http://localhost/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "What is Deep Learning?",
+    "model": "text-embeddings-inference",
+    "encoding_format": "float"
+  }'
+``
+
+Alternatively, you can also send the request with cURL as follows:
 ```bash
 curl http://localhost:8080/v1/embeddings \
   -H "Content-Type: application/json" \

--- a/docs/source/en/quick_tour.md
+++ b/docs/source/en/quick_tour.md
@@ -77,6 +77,7 @@ print(len(embedding[0]))
 ```
 
 #### OpenAI
+The server is availabe at : localhost:8080/v1/embeddings
 
 You can install it via pip as `pip install --upgrade openai`, and then run:
 
@@ -84,14 +85,14 @@ You can install it via pip as `pip install --upgrade openai`, and then run:
 import os
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8080/v1/embeddings")
+client = OpenAI(base_url="http://localhost:8080/v1", api_key= "fake")
 
 response = client.embeddings.create(
   model="tei",
   input="What is deep learning?"
 )
 
-print(response)
+print(response.data[0].embedding)
 ```
 
 ## Re-rankers and sequence classification

--- a/docs/source/en/quick_tour.md
+++ b/docs/source/en/quick_tour.md
@@ -77,22 +77,31 @@ print(len(embedding[0]))
 ```
 
 #### OpenAI
-The server is availabe at : localhost:8080/v1/embeddings
-
-You can install it via pip as `pip install --upgrade openai`, and then run:
+To send requests to the [OpenAI Embeddings API](https://platform.openai.com/docs/api-reference/embeddings/create) exposed on Text Embeddings Inference (TEI) with the OpenAI Python SDK, you can install it as `pip install --upgrade openai`, and then run the following snippet:
 
 ```python
 import os
 from openai import OpenAI
 
-client = OpenAI(base_url="http://localhost:8080/v1", api_key= "fake")
+client = OpenAI(base_url="http://localhost:8080/v1", api_key= "-")
 
 response = client.embeddings.create(
-  model="tei",
-  input="What is deep learning?"
+    model="text-embeddings-inference",
+    input="What is Deep Learning?",
 )
 
 print(response.data[0].embedding)
+```
+
+Alternatively, you can also send the request with cURL as follows:
+```bash
+curl http://localhost:8080/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "What is Deep Learning?",
+    "model": "text-embeddings-inference",
+    "encoding_format": "float"
+  }'
 ```
 
 ## Re-rankers and sequence classification


### PR DESCRIPTION
### Title

**docs(tei): fix OpenAI client usage example for embeddings**

---

### PR Description

This PR updates the documentation for using the OpenAI Python client with TEI’s OpenAI-compatible API.
The previous example incorrectly set the `base_url` to `/v1/embeddings`, which caused errors.
It also did not mention that the OpenAI client requires an `api_key` argument (even if unused by TEI).

**Changes made:**

* Corrected the `base_url` to `http://localhost:8080/v1`
* Added `api_key="fake"` to satisfy the OpenAI client requirements
* Updated the example to print `response.data[0].embedding` for clarity

**Motivation:**
Improve usability of the TEI docs by providing a working out-of-the-box example for developers who want to use the OpenAI client with TEI.

**Fixes:**
N/A (documentation improvement)

---

### Before submitting

* [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
* [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
* [x] Did you make sure to update the documentation with your changes?
* [x] Tests not applicable (docs-only change).

---

### Who can review?

Tagging maintainer for review:
@Narsil
