### PR TITLE
Handle `HF_TOKEN` in `ApiBuilder` for `candle/tests`

### DIFF
--- a/backends/candle/tests/common.rs
+++ b/backends/candle/tests/common.rs
@@ -133,12 +133,12 @@ pub fn download_artifacts(
 ) -> Result<(PathBuf, Option<Vec<String>>)> {
     let mut builder = ApiBuilder::from_env().with_progress(false);
 
-    if let Some(cache_dir) = std::env::var_os("HUGGINGFACE_HUB_CACHE") {
-        builder = builder.with_cache_dir(cache_dir.into());
+    if let Ok(token) = std::env::var("HF_TOKEN") {
+        builder = builder.with_token(Some(token));
     }
 
-    if let Ok(origin) = std::env::var("HF_HUB_USER_AGENT_ORIGIN") {
-        builder = builder.with_user_agent("origin", origin.as_str());
+    if let Some(cache_dir) = std::env::var_os("HUGGINGFACE_HUB_CACHE") {
+        builder = builder.with_cache_dir(cache_dir.into());
     }
 
     let api = builder.build().unwrap();


### PR DESCRIPTION
# What does this PR do?

This PR adds the `HF_TOKEN` handling within the `ApiBuilder` for the `download_artifacts` function in the `backends/candle/tests` as it was required for #718, given that `HF_TOKEN` is not automatically parsed and it was mistaken with the cached Hugging Face Token, hence the CI was failing but that was unrelated to the token used in CI, but rather to a wrong configuration around `ApiBuilder` (kudos to @paulinebm for spotting, and thanks also to @glegendre01 for helping out with the `HF_TOKEN`).

Additionally, this PR removes the `HF_HUB_USER_AGENT_ORIGIN` environment variable handling for the tests as it's never defined and not really used at all.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [X] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.