### PR TITLE
Update `version` to 1.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "backend-grpc-client"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "grpc-metadata",
  "prost 0.11.9",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-backend"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "clap",
  "hf-hub",
@@ -4493,7 +4493,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-backend-candle"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "accelerate-src",
  "anyhow",
@@ -4523,7 +4523,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-backend-core"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "clap",
  "nohash-hasher",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-backend-ort"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "anyhow",
  "ndarray",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-backend-python"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "backend-grpc-client",
  "nohash-hasher",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-core"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "async-channel",
  "hf-hub",
@@ -4579,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "text-embeddings-router"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.8.2"
+version = "1.8.3"
 edition = "2021"
 authors = ["Olivier Dehaene", "Nicolas Patry", "Alvaro Bartolome"]
 homepage = "https://github.com/huggingface/text-embeddings-inference"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10,7 +10,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0"
     },
-    "version": "1.8.2"
+    "version": "1.8.3"
   },
   "paths": {
     "/decode": {


### PR DESCRIPTION
# What does this PR do?

This PR is prior the v1.8.3 release, and contains the following:
- Update `version` in `Cargo.toml`
- Upload automatically updated `Cargo.lock`
- Export latest `openapi.json` OpenAPI schemas

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc @kozistr, @vrdn-23 and @dstnluong-google for visibility