### PR TITLE
Fix reading non-standard config for `past_key_values` in ONNX

### DIFF
--- a/backends/ort/src/lib.rs
+++ b/backends/ort/src/lib.rs
@@ -15,10 +15,16 @@ use text_embeddings_backend_core::{
 pub struct Config {
     pub pad_token_id: Option<usize>,
     pub eos_token_id: Option<usize>,
-    // NOTE: the fields below are only required when the ONNX model expects the `past_key_values`
-    // as input i.e., whenever the ONNX model has been exported with optimized MHA nodes
+
+    // NOTE: The fields below are only required when the ONNX model expects the `past_key_values`
+    // as input i.e., whenever the ONNX model has been exported with optimized MHA/MQA nodes
+    // NOTE: The renames from `n_embd`, `n_layer`, and `n_head` have been included for some edge
+    // cases as e.g. `nomic-ai/nomic-embed-text-v1`, given that those ONNX exports use MQA
+    #[serde(rename = "n_embd")]
     pub hidden_size: usize,
+    #[serde(rename = "n_layer")]
     pub num_hidden_layers: usize,
+    #[serde(rename = "n_head")]
     pub num_key_value_heads: Option<usize>,
 }
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes how the `config.json` is read for e.g. `nomic-ai/nomic-embed-text-v1` doesn't use the standard naming for the `hidden_size`, `num_hidden_layers`, and `num_key_value_heads`, but rather `n_embd`, `n_layer`, and `n_head`, respectively.

> [!NOTE]
> Note that this is required given that the ONNX export for e.g. `nomic-ai/nomic-embed-text-v1` is using optimized MHA/MQA nodes, hence the need for the reading the `config.json` to properly parse the `past_key_values` weights on the ONNX export.

Fixes #750 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.