### PR TITLE
Fix `TruncationDirection` to deserialize from lowercase and capitalized

### DIFF
--- a/router/src/http/types.rs
+++ b/router/src/http/types.rs
@@ -194,9 +194,10 @@ impl<'__s> ToSchema<'__s> for PredictInput {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize, ToSchema, Eq, Default)]
-#[serde(rename_all = "lowercase")]
 pub(crate) enum TruncationDirection {
+    #[serde(alias = "left", alias = "Left")]
     Left,
+    #[serde(alias = "right", alias = "Right")]
     #[default]
     Right,
 }


### PR DESCRIPTION
# What does this PR do?

This PR adds `#[serde(alias = "...")]` to `TruncationDirection` on HTTP to make sure that the enum variants deserialize from lowercase too e.g. `{..., "truncation_direction":"left", ...}` as previously it was only deserializing from the enum variant counterpart e.g., `Left`.

This PR partially fixes #754, but there's still some more issues to tackle as per the `openapi.json` specification as reported in the issue.

> [!WARNING]
> Rather than removing the "Left" and "Right" values enforcing those to be lowercased, to make sure this is introduced in the best way possible, from now on both variants (lowercase and capitalized) are supported for `truncation_direction` but only the lowercase will be recommended.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.

cc @Wauplin for visibility!