### PR TITLE
candle: health check by queuing on cuda

### DIFF
--- a/backends/candle/src/lib.rs
+++ b/backends/candle/src/lib.rs
@@ -584,16 +584,17 @@ impl Backend for CandleBackend {
         // Simple healthcheck by performing a trivial operation
         // backend is almost unfailable, but e.g. Cuda OOM or cuda "device fallen off the bus"
         // can be detected this way
-        use candle_core::Tensor;
+        use candle::Tensor;
 
         // 1) enqueue a trivial op on the current device
         let x = Tensor::new(&[1f32], &self.device).e()?;
-        let y = (&x * 2f32).e()?;
+        let z = Tensor::new(&[2f32], &self.device).e()?;
+        let y = (&x * &z).e()?;
 
-        // 2) force completion + surface async CUDA errors by reading back
+        // 2) move storage to CPU to surface async CUDA errors by reading back
         let v = y.to_vec1::<f32>().e()?;
         if v.len() != 1 || (v[0] - 2.0).abs() > 1e-6 {
-            // ideally, we should sleep here for 1.0s to allow k8s to detect healthcheck failure
+            // michaelfeil: ideally, we should sleep here for 1.0s/5.0s to allow k8s to detect healthcheck failure
             // without queuing further work on a possibly broken device by blocking the backend.
             // and sending 429s in the meantime.
             return Err(BackendError::Inference(format!(

--- a/backends/candle/src/lib.rs
+++ b/backends/candle/src/lib.rs
@@ -597,10 +597,12 @@ impl Backend for CandleBackend {
             // michaelfeil: ideally, we should sleep here for 1.0s/5.0s to allow k8s to detect healthcheck failure
             // without queuing further work on a possibly broken device by blocking the backend.
             // and sending 429s in the meantime.
+            tracing::error!("Device {:?} healthcheck failed: expected [2.0], got {v:?}", self.device);
             return Err(BackendError::Inference(format!(
                 "device healthcheck failed: expected [2.0], got {v:?}"
             )));
         }
+        tracing::debug!("Device {:?} healthcheck passed", self.device);
 
         Ok(())
     }


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #775 

Fixes a crucial health check, that when a GPU has a driver failure (fallen of the bus etc, or CUDA OOM). TEI technically is very unlikley to OOM during runtime, as it allocates only ~10-20MB more than during warmup in some edge cases. I have never seen it OOM on cuda. 
However, if you have a driver issue, #775 fails. To make things worse, the way things are set up in k8s is that once one replica starts erroring at very fast rates, it might consume a lot of requests. (more than healthy replicas, making incidents worse)

On CPU , works great, compiled via
```
cargo build --release --bin text-embeddings-router -F candle -F dynamic-linking -F http --no-default-features
```

```
2025-12-17T19:59:30.262188Z  INFO health:health:health: text_embeddings_backend_candle: backends/candle/src/lib.rs:605: Device Cpu healthcheck passed
2025-12-17T19:59:32.116511Z  INFO health:health:health: text_embeddings_backend_candle: backends/candle/src/lib.rs:605: Device Cpu healthcheck passed
2025-12-17T19:59:33.330219Z  INFO health:health:health: text_embeddings_backend_candle: backends/candle/src/lib.rs:605: Device Cpu healthcheck passed
2025-12-17T19:59:34.256090Z  INFO health:health:health: text_embeddings_backend_candle: backends/candle/src/lib.rs:605: Device Cpu healthcheck passed
2025-12-17T19:59:35.548203Z  INFO health:health:health: text_embeddings_backend_candle: backends/candle/src/lib.rs:605: Device Cpu healthcheck passed
```
On GPU, works great, compiled via `cargo build --release --bin text-embeddings-router -F candle-cuda -F dynamic-linking -F http --no-default-features`

```
2025-12-17T19:52:10.256396Z  INFO text_embeddings_router::http::server: router/src/http/server.rs:1853: Ready
2025-12-17T19:52:18.663691Z  INFO health:health:health: text_embeddings_backend_candle: backends/candle/src/lib.rs:604: Device Cuda(CudaDevice(DeviceId(1))) healthcheck passed
2025-12-17T19:52:22.167088Z  INFO health:health:health: text_embeddings_backend_candle: backends/candle/src/lib.rs:604: Device Cuda(CudaDevice(DeviceId(1))) healthcheck passed
2025-12-17T19:52:34.347053Z  INFO health:health:health: text_embeddings_backend_candle: backends/candle/src/lib.rs:604: Device Cuda(CudaDevice(DeviceId(1))) healthcheck passed
2025-12-17T19:52:36.060119Z  INFO health:health:he
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

@Narsil OR @alvarobartt

 -->
