### PR TITLE
feat/jina embeddings v4

### DIFF
--- a/backends/candle/src/models/mod.rs
+++ b/backends/candle/src/models/mod.rs
@@ -90,7 +90,7 @@ pub use flash_modernbert::FlashModernBertModel;
 pub use flash_nomic::FlashNomicBertModel;
 
 #[cfg(feature = "cuda")]
-pub use flash_qwen2::FlashQwen2Model;
+pub use flash_qwen2::{FlashQwen2Model, LoraWeights};
 
 #[cfg(feature = "cuda")]
 pub use flash_qwen3::FlashQwen3Model;

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -146,7 +146,7 @@ pub async fn run(
     // Old Qwen2  repos updates the post processor manually instead of into the tokenizer.json.
     // Newer ones (https://huggingface.co/jinaai/jina-code-embeddings-0.5b/tree/main) have it in the tokenizer.json. This is to support both cases.
     // https://huggingface.co/Alibaba-NLP/gte-Qwen2-1.5B-instruct/blob/main/tokenization_qwen.py#L246
-    if config.model_type() == Some("qwen2")
+    if config.model_type == "qwen2"
         && config
             .auto_map
             .as_ref()
@@ -174,10 +174,10 @@ pub async fn run(
     }
 
     // Position IDs offset. Used for Roberta and camembert.
-    let position_offset = if matches!(
-        config.model_type(),
-        Some("xlm-roberta") | Some("camembert") | Some("roberta")
-    ) {
+    let position_offset = if &config.model_type == "xlm-roberta"
+        || &config.model_type == "camembert"
+        || &config.model_type == "roberta"
+    {
         config.pad_token_id + 1
     } else {
         0
@@ -265,7 +265,7 @@ pub async fn run(
     // NOTE: `gemma3_text` won't support Float16 but only Float32, given that with `candle-cuda`
     // feature, the default `Dtype::Float16` this overrides that to prevent issues when running a
     // `gemma3_text` model without specifying a `--dtype`
-    let dtype = if dtype.is_none() && config.model_type() == Some("gemma3_text") {
+    let dtype = if dtype.is_none() && config.model_type == "gemma3_text" {
         DType::Float32
     } else {
         dtype.unwrap_or_default()
@@ -446,10 +446,7 @@ fn get_backend_model_type(
                     Pool::try_from(config)?
                 }
                 Err(err) => {
-                    let is_bert = config
-                        .model_type()
-                        .is_some_and(|t| t.to_lowercase().contains("bert"));
-                    if !is_bert {
+                    if !config.model_type.to_lowercase().contains("bert") {
                         return Err(err).context("The `--pooling` arg is not set and we could not find a pooling configuration (`1_Pooling/config.json`) for this model.");
                     }
                     tracing::warn!("The `--pooling` arg is not set and we could not find a pooling configuration (`1_Pooling/config.json`) for this model but the model is a BERT variant. Defaulting to `CLS` pooling.");
@@ -465,31 +462,15 @@ fn get_backend_model_type(
 #[derive(Debug, Deserialize)]
 pub struct ModelConfig {
     pub architectures: Vec<String>,
-    pub model_type: Option<String>,
+    #[serde(default)]
+    pub model_type: String,
     #[serde(alias = "n_positions")]
     pub max_position_embeddings: usize,
     #[serde(default)]
     pub pad_token_id: usize,
-    #[serde(default)]
-    pub text_config: Option<TextConfig>,
     pub id2label: Option<HashMap<String, String>>,
     pub label2id: Option<HashMap<String, usize>>,
     pub auto_map: Option<HashMap<String, String>>,
-}
-
-impl ModelConfig {
-    fn model_type(&self) -> Option<&str> {
-        self.model_type
-            .as_deref()
-            .or_else(|| self.text_config.as_ref()?.model_type.as_deref())
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub struct TextConfig {
-    pub model_type: Option<String>,
-    #[serde(default)]
-    pub sliding_window: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -114,14 +114,12 @@ pub async fn run(
         text_embeddings_backend::ModelType::Classifier => {
             let id2label = config
                 .id2label
-                .clone()
                 .context("`config.json` does not contain `id2label`")?;
             let n_classes = id2label.len();
             let classifier_model = ClassifierModel {
                 id2label,
                 label2id: config
                     .label2id
-                    .clone()
                     .context("`config.json` does not contain `label2id`")?,
             };
             if n_classes > 1 {


### PR DESCRIPTION
# What does this PR do?

This PR adds full support for **Jina Embeddings v4** across routing, backend handling, and documentation.

### Summary of changes

- **Model detection & routing**
  - Detects `JinaEmbeddingsV4Model` and `text_config` fields in `config.json`
  - Applies `sliding_window` logic to respect max input length
  - Treats Jina v4 as an **embedding model with mean pooling by default** in the router

- **Python backend support**
  - Adds a Python backend handler for **Jina v4** (remote code + LoRA support)
  - Returns `single_vec_emb`
  - Supports automatic task selection, with optional override via `JINA_V4_TASK`

- **Build & test improvements**
  - Improves default dtype handling for **gRPC-only builds**
  - Fixes tokenizer test to use the **Tokio API**

- **Documentation**
  - Documents Jina v4 usage in the README
  - Adds Jina v4 to the supported models list

Fixes # (no issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? (No)
- [x] Did you make sure to update the documentation with your changes? (README + supported_models)
- [x] Did you write any new necessary tests?  
      - Workspace tests  
      - Jina integration tests  
      - Tokenizer test updated to use Tokio API

## Who can review?

@Narsil  
@alvarobartt