### PR TITLE
Adjust the warmup phase for CPU

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -290,7 +290,12 @@ pub async fn run(
 
     tracing::info!("Warming up model");
     backend
-        .warmup(max_input_length, max_batch_tokens, max_batch_requests)
+        .warmup(
+            max_input_length,
+            max_batch_tokens,
+            max_batch_requests,
+            backend.padded_model,
+        )
         .await
         .context("Model backend is not healthy")?;
 


### PR DESCRIPTION
# What does this PR do?

Related to #758 

The warmup phase takes a long time on the CPU (or causes OOM) due to the large `max_input_length`, such as 16384, and it might appear to be hanging because it's taking too long.

I've adjusted the `warmup_tokens` (== `max_batch_tokens`) to `max_input_length` for a faster startup on the CPU.

Or, perhaps we could just skip warming up on the CPU if there's no significant benefit to warming up onnx model.

Feel free to give any thoughts and feedback!

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [x] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@alvarobartt