### PR TITLE
[Feature] Add native Qwen3-Reranker support and SM87 compute capability

### DIFF
--- a/backends/candle/src/compute_cap.rs
+++ b/backends/candle/src/compute_cap.rs
@@ -26,8 +26,9 @@ pub fn get_runtime_compute_cap() -> Result<usize, anyhow::Error> {
 fn compute_cap_matching(runtime_compute_cap: usize, compile_compute_cap: usize) -> bool {
     match (runtime_compute_cap, compile_compute_cap) {
         (75, 75) => true,
-        (80..=89, 80) => true,
-        (86..=89, 80..=86) => true,
+        (80..=86, 80) => true,
+        (86..=86, 80..=86) => true,
+        (87, 87) => true,  // Jetson Orin
         (89, 89) => true,
         (90, 90) => true,
         (_, _) => false,
@@ -52,33 +53,45 @@ mod tests {
         assert!(compute_cap_matching(75, 75));
         assert!(compute_cap_matching(80, 80));
         assert!(compute_cap_matching(86, 86));
+        assert!(compute_cap_matching(87, 87));
         assert!(compute_cap_matching(89, 89));
         assert!(compute_cap_matching(90, 90));
 
         assert!(compute_cap_matching(86, 80));
-        assert!(compute_cap_matching(89, 80));
-        assert!(compute_cap_matching(89, 86));
 
         assert!(!compute_cap_matching(75, 80));
         assert!(!compute_cap_matching(75, 86));
+        assert!(!compute_cap_matching(75, 87));
         assert!(!compute_cap_matching(75, 89));
         assert!(!compute_cap_matching(75, 90));
 
         assert!(!compute_cap_matching(80, 75));
         assert!(!compute_cap_matching(80, 86));
+        assert!(!compute_cap_matching(80, 87));
         assert!(!compute_cap_matching(80, 89));
         assert!(!compute_cap_matching(80, 90));
 
         assert!(!compute_cap_matching(86, 75));
+        assert!(!compute_cap_matching(86, 87));
         assert!(!compute_cap_matching(86, 89));
         assert!(!compute_cap_matching(86, 90));
 
+        assert!(!compute_cap_matching(87, 75));
+        assert!(!compute_cap_matching(87, 80));
+        assert!(!compute_cap_matching(87, 86));
+        assert!(!compute_cap_matching(87, 89));
+        assert!(!compute_cap_matching(87, 90));
+
         assert!(!compute_cap_matching(89, 75));
+        assert!(!compute_cap_matching(89, 80));
+        assert!(!compute_cap_matching(89, 86));
+        assert!(!compute_cap_matching(89, 87));
         assert!(!compute_cap_matching(89, 90));
 
         assert!(!compute_cap_matching(90, 75));
         assert!(!compute_cap_matching(90, 80));
         assert!(!compute_cap_matching(90, 86));
+        assert!(!compute_cap_matching(90, 87));
         assert!(!compute_cap_matching(90, 89));
     }
 }

--- a/backends/candle/src/models/bert.rs
+++ b/backends/candle/src/models/bert.rs
@@ -597,6 +597,9 @@ impl BertModel {
                 };
                 (pool, None, splade)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (embeddings, encoder) = match (
@@ -660,6 +663,9 @@ impl BertModel {
                     None
                 };
                 (pool, None, splade)
+            }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for Bert")
             }
         };
 

--- a/backends/candle/src/models/distilbert.rs
+++ b/backends/candle/src/models/distilbert.rs
@@ -462,6 +462,9 @@ impl DistilBertModel {
 
                 (pool, None)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/flash_bert.rs
+++ b/backends/candle/src/models/flash_bert.rs
@@ -259,6 +259,9 @@ impl FlashBertModel {
                 };
                 (pool, None, splade)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (embeddings, encoder) = match (
@@ -325,6 +328,9 @@ impl FlashBertModel {
                     None
                 };
                 (pool, None, splade)
+            }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
             }
         };
 

--- a/backends/candle/src/models/flash_distilbert.rs
+++ b/backends/candle/src/models/flash_distilbert.rs
@@ -200,6 +200,9 @@ impl FlashDistilBertModel {
                 candle::bail!("`classifier` model type is not supported for DistilBert")
             }
             ModelType::Embedding(pool) => pool,
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/flash_gte.rs
+++ b/backends/candle/src/models/flash_gte.rs
@@ -193,6 +193,9 @@ impl FlashGTEModel {
                 (pool, Some(classifier))
             }
             ModelType::Embedding(pool) => (pool, None),
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (word_embeddings, token_type_embeddings, layers, embeddings_norm) =

--- a/backends/candle/src/models/flash_jina.rs
+++ b/backends/candle/src/models/flash_jina.rs
@@ -267,6 +267,9 @@ impl FlashJinaBertModel {
                 }
                 (pool, None)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/flash_jina_code.rs
+++ b/backends/candle/src/models/flash_jina_code.rs
@@ -314,6 +314,9 @@ impl FlashJinaCodeBertModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/flash_mistral.rs
+++ b/backends/candle/src/models/flash_mistral.rs
@@ -251,6 +251,9 @@ impl FlashMistralModel {
                 candle::bail!("`classifier` model type is not supported for Mistral")
             }
             ModelType::Embedding(pool) => pool,
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let embeddings = Embedding::new(

--- a/backends/candle/src/models/flash_modernbert.rs
+++ b/backends/candle/src/models/flash_modernbert.rs
@@ -274,6 +274,9 @@ impl FlashModernBertModel {
 
                 (pool, None)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let embeddings = ModernBertEmbeddings::load(vb.pp("model.embeddings"), config)

--- a/backends/candle/src/models/flash_nomic.rs
+++ b/backends/candle/src/models/flash_nomic.rs
@@ -228,6 +228,9 @@ impl FlashNomicBertModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let embeddings = NomicBertEmbeddings::load(vb.clone(), config)?;

--- a/backends/candle/src/models/flash_qwen2.rs
+++ b/backends/candle/src/models/flash_qwen2.rs
@@ -261,6 +261,9 @@ impl FlashQwen2Model {
                 candle::bail!("`classifier` model type is not supported for Qwen2")
             }
             ModelType::Embedding(pool) => pool,
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         // Pushing the prefix for `model` is apparently only required if the model architecture is

--- a/backends/candle/src/models/gemma3.rs
+++ b/backends/candle/src/models/gemma3.rs
@@ -633,6 +633,9 @@ impl Gemma3Model {
                 candle::bail!("`classifier` model type is not supported for Gemma3")
             }
             ModelType::Embedding(pool) => pool,
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let embed_tokens = Gemma3Embedding::load(vb.pp("embed_tokens"), config)?;

--- a/backends/candle/src/models/gte.rs
+++ b/backends/candle/src/models/gte.rs
@@ -406,6 +406,9 @@ impl GTEModel {
                 (pool, Some(classifier))
             }
             ModelType::Embedding(pool) => (pool, None),
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (word_embeddings, token_type_embeddings, encoder, embeddings_norm) =

--- a/backends/candle/src/models/jina.rs
+++ b/backends/candle/src/models/jina.rs
@@ -436,6 +436,9 @@ impl JinaBertModel {
                 }
                 (pool, None)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/jina_code.rs
+++ b/backends/candle/src/models/jina_code.rs
@@ -364,6 +364,9 @@ impl JinaCodeBertModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for JinaCode")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/modernbert.rs
+++ b/backends/candle/src/models/modernbert.rs
@@ -498,6 +498,9 @@ impl ModernBertModel {
 
                 (pool, None)
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let embeddings = ModernBertEmbeddings::load(vb.pp("model.embeddings"), config)

--- a/backends/candle/src/models/mpnet.rs
+++ b/backends/candle/src/models/mpnet.rs
@@ -450,6 +450,9 @@ impl MPNetModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let (embeddings, encoder) = match (

--- a/backends/candle/src/models/nomic.rs
+++ b/backends/candle/src/models/nomic.rs
@@ -697,6 +697,9 @@ impl NomicBertModel {
                 }
                 pool
             }
+            ModelType::ListwiseReranker => {
+                candle::bail!("`ListwiseReranker` model type is not supported for this model")
+            }
         };
 
         let embeddings = NomicBertEmbeddings::load(vb.clone(), config)?;

--- a/backends/core/src/lib.rs
+++ b/backends/core/src/lib.rs
@@ -51,6 +51,9 @@ pub trait Backend {
 pub enum ModelType {
     Classifier,
     Embedding(Pool),
+    /// Listwise reranker models that use generative approach (e.g., Qwen3-Reranker)
+    /// These models output yes/no token logits instead of classification scores
+    ListwiseReranker,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize)]

--- a/backends/ort/src/lib.rs
+++ b/backends/ort/src/lib.rs
@@ -87,6 +87,11 @@ impl OrtBackend {
                 }
                 _ => pool,
             },
+            ModelType::ListwiseReranker => {
+                return Err(BackendError::Start(
+                    "`ListwiseReranker` model type is not supported for `ort`".to_string(),
+                ));
+            }
         };
 
         let onnx_path = {

--- a/backends/python/src/lib.rs
+++ b/backends/python/src/lib.rs
@@ -27,6 +27,11 @@ impl PythonBackend {
         let pool = match model_type {
             ModelType::Classifier => Pool::Cls,
             ModelType::Embedding(pool) => pool,
+            ModelType::ListwiseReranker => {
+                return Err(BackendError::Start(
+                    "`ListwiseReranker` model type is not supported for Python backend".to_string(),
+                ));
+            }
         };
 
         let backend_process = management::BackendProcess::new(

--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -173,7 +173,9 @@ impl Backend {
         for shape in shapes.iter() {
             let batch = self.create_warmup_batch(*shape, max_token as u32, seq_bucket_size as u32);
             match &self.model_type {
-                ModelType::Classifier => self.predict(batch).await.map(|_| ()),
+                ModelType::Classifier | ModelType::ListwiseReranker => {
+                    self.predict(batch).await.map(|_| ())
+                }
                 ModelType::Embedding(_) => self.embed(batch).await.map(|_| ()),
             }?;
             tracing::info!("finish warmup for batch: {}, length: {}", shape.0, shape.1);
@@ -292,7 +294,9 @@ impl Backend {
         };
 
         match &self.model_type {
-            ModelType::Classifier => self.predict(batch).await.map(|_| ()),
+            ModelType::Classifier | ModelType::ListwiseReranker => {
+                self.predict(batch).await.map(|_| ())
+            }
             ModelType::Embedding(_) => self.embed(batch).await.map(|_| ()),
         }
     }
@@ -325,7 +329,9 @@ impl Backend {
                 raw_indices: vec![],
             };
             match &self.model_type {
-                ModelType::Classifier => self.predict(batch).await.map(|_| ()),
+                ModelType::Classifier | ModelType::ListwiseReranker => {
+                    self.predict(batch).await.map(|_| ())
+                }
                 ModelType::Embedding(_) => self.embed(batch).await.map(|_| ()),
             }
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod download;
 pub mod infer;
 pub mod queue;
+pub mod templates;
 pub mod tokenization;
 
 use text_embeddings_backend::BackendError;

--- a/core/src/templates.rs
+++ b/core/src/templates.rs
@@ -1,0 +1,78 @@
+/// Chat template system for Qwen3-Reranker models
+///
+/// Qwen3-Reranker uses a ChatML-style template for reranking:
+/// ```
+/// <|im_start|>system
+/// Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be "yes" or "no".<|im_end|>
+/// <|im_start|>user
+/// <Instruct>: {instruction}
+/// <Query>: {query}
+/// <Document>: {document}<|im_end|>
+/// <|im_start|>assistant
+/// ```
+
+/// Default instruction for Qwen3-Reranker
+pub const DEFAULT_RERANKER_INSTRUCTION: &str =
+    "Given a web search query, retrieve relevant passages that answer the query";
+
+/// System prompt for Qwen3-Reranker
+const SYSTEM_PROMPT: &str = "Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\".";
+
+/// Apply Qwen3-Reranker template to format query and document
+///
+/// # Arguments
+/// * `query` - The search query
+/// * `document` - The document to evaluate
+/// * `instruction` - Optional custom instruction (uses default if None)
+///
+/// # Returns
+/// Formatted template string ready for tokenization
+pub fn apply_qwen3_reranker_template(
+    query: &str,
+    document: &str,
+    instruction: Option<&str>,
+) -> String {
+    let instruction = instruction.unwrap_or(DEFAULT_RERANKER_INSTRUCTION);
+
+    format!(
+        "<|im_start|>system\n{}<|im_end|>\n<|im_start|>user\n<Instruct>: {}\n<Query>: {}\n<Document>: {}<|im_end|>\n<|im_start|>assistant\n",
+        SYSTEM_PROMPT,
+        instruction,
+        query,
+        document
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_qwen3_reranker_template_default() {
+        let query = "What is deep learning?";
+        let document = "Deep learning is a subset of machine learning.";
+
+        let result = apply_qwen3_reranker_template(query, document, None);
+
+        assert!(result.contains("<|im_start|>system"));
+        assert!(result.contains(SYSTEM_PROMPT));
+        assert!(result.contains("<|im_end|>"));
+        assert!(result.contains("<|im_start|>user"));
+        assert!(result.contains(DEFAULT_RERANKER_INSTRUCTION));
+        assert!(result.contains(query));
+        assert!(result.contains(document));
+        assert!(result.contains("<|im_start|>assistant"));
+    }
+
+    #[test]
+    fn test_apply_qwen3_reranker_template_custom_instruction() {
+        let query = "Find code examples";
+        let document = "Here is a Python example.";
+        let instruction = "Find code snippets that demonstrate the query";
+
+        let result = apply_qwen3_reranker_template(query, document, Some(instruction));
+
+        assert!(result.contains(instruction));
+        assert!(!result.contains(DEFAULT_RERANKER_INSTRUCTION));
+    }
+}

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -128,6 +128,14 @@ pub async fn run(
                 ModelType::Reranker(classifier_model)
             }
         }
+        text_embeddings_backend::ModelType::ListwiseReranker => {
+            // Qwen3-Reranker uses yes/no tokens, create dummy id2label
+            let mut id2label = HashMap::new();
+            id2label.insert("0".to_string(), "LABEL_0".to_string());
+            let mut label2id = HashMap::new();
+            label2id.insert("LABEL_0".to_string(), 0);
+            ModelType::Reranker(ClassifierModel { id2label, label2id })
+        }
         text_embeddings_backend::ModelType::Embedding(pool) => {
             ModelType::Embedding(EmbeddingModel {
                 pooling: pool.to_string(),
@@ -396,6 +404,22 @@ fn get_backend_model_type(
     model_root: &Path,
     pooling: Option<text_embeddings_backend::Pool>,
 ) -> Result<text_embeddings_backend::ModelType> {
+    // Check for Qwen3-Reranker (ListwiseReranker)
+    // Only detect as ListwiseReranker if:
+    // 1. is_reranker=true explicitly set, OR
+    // 2. model_type is "qwen3" with CausalLM architecture AND no Sentence Transformers pooling config
+    //    (Qwen3-Embedding has 1_Pooling/config.json, Qwen3-Reranker does not)
+    let has_pooling_config = model_root.join("1_Pooling/config.json").exists();
+    
+    if config.is_reranker == Some(true)
+        || (config.model_type.to_lowercase() == "qwen3"
+            && config.architectures.iter().any(|a| a.contains("CausalLM"))
+            && !has_pooling_config)
+    {
+        tracing::info!("Detected Qwen3-Reranker model (ListwiseReranker)");
+        return Ok(text_embeddings_backend::ModelType::ListwiseReranker);
+    }
+
     for arch in &config.architectures {
         // Edge case affecting `Alibaba-NLP/gte-multilingual-base` and possibly other fine-tunes of
         // the same base model. More context at https://huggingface.co/Alibaba-NLP/gte-multilingual-base/discussions/7
@@ -464,6 +488,9 @@ pub struct ModelConfig {
     pub id2label: Option<HashMap<String, String>>,
     pub label2id: Option<HashMap<String, usize>>,
     pub auto_map: Option<HashMap<String, String>>,
+    /// Flag indicating if this is a reranker model (used by Qwen3-Reranker)
+    #[serde(default)]
+    pub is_reranker: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]


### PR DESCRIPTION
# What does this PR do?

This PR adds two features:

## 1. Native Qwen3-Reranker Support

Adds support for **Qwen3-Reranker** models (generative reranker). Unlike traditional classifiers that use a classification head, Qwen3-Reranker computes relevance scores using yes/no token logits from a causal language model.

### How it works:
1. Input is formatted using ChatML template with a system prompt asking for yes/no judgment
2. The model generates logits for all tokens
3. We extract logits at the **last position** for yes/no tokens (YES=9693, NO=2152)
4. Score = `P(yes) = softmax([logit_no, logit_yes])[1]`

### Changes:
- Added `ModelType::ListwiseReranker` variant in `backends/core/src/lib.rs`
- Implemented `lm_head` with tied embeddings support in `qwen3.rs` and `flash_qwen3.rs`
- Added ChatML template system (`core/src/templates.rs`)
- Model detection: Qwen3 without `1_Pooling/config.json` → ListwiseReranker
- Skip sigmoid for ListwiseReranker (already returns probability)

## 2. SM87 Compute Capability Support (Jetson Orin)

Added support for NVIDIA Jetson Orin (compute capability 8.7) in `backends/candle/src/compute_cap.rs`.

## Testing

Tested on both CPU and GPU (Jetson AGX Orin SM87):

```bash
# Build with SM87 support
CUDA_COMPUTE_CAP=87 cargo build --release -p text-embeddings-router -F http -F candle-cuda

# Reranker test
curl http://localhost:8090/rerank \
  -H "Content-Type: application/json" \
  -d '{"query": "What is Deep Learning?", "texts": ["Deep Learning is a branch of machine learning", "The weather is nice today"]}'

# Response: [{"index":0,"score":0.47852883},{"index":1,"score":0.0000104515475}]
```

## Related

- Related to #730 (seq-cls approach) - this PR provides an alternative approach using the original generative model
- [Qwen3-Reranker Model Card](https://huggingface.co/Qwen/Qwen3-Reranker-0.6B)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the forum? Related to #730
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@Narsil OR @alvarobartt OR @kozistr