### PR TITLE
Fix `rustfmt` on `backend/candle/tests/*.rs` files

### DIFF
--- a/backends/candle/tests/test_bert.rs
+++ b/backends/candle/tests/test_bert.rs
@@ -165,9 +165,7 @@ fn test_emotions() -> Result<()> {
 
     let matcher = relative_matcher();
 
-    let predictions: Vec<Vec<f32>> = backend
-        .predict(input_batch)?.into_values()
-        .collect();
+    let predictions: Vec<Vec<f32>> = backend.predict(input_batch)?.into_values().collect();
     let predictions_batch = SnapshotScores::from(predictions);
     insta::assert_yaml_snapshot!("emotions_batch", predictions_batch, &matcher);
 
@@ -177,9 +175,7 @@ fn test_emotions() -> Result<()> {
         vec![],
     );
 
-    let predictions: Vec<Vec<f32>> = backend
-        .predict(input_single)?.into_values()
-        .collect();
+    let predictions: Vec<Vec<f32>> = backend.predict(input_single)?.into_values().collect();
     let predictions_single = SnapshotScores::from(predictions);
 
     insta::assert_yaml_snapshot!("emotions_single", predictions_single, &matcher);
@@ -217,9 +213,7 @@ fn test_bert_classification() -> Result<()> {
         vec![],
     );
 
-    let predictions: Vec<Vec<f32>> = backend
-        .predict(input_single)?.into_values()
-        .collect();
+    let predictions: Vec<Vec<f32>> = backend.predict(input_single)?.into_values().collect();
     let predictions_single = SnapshotScores::from(predictions);
 
     let matcher = relative_matcher();

--- a/backends/candle/tests/test_dense.rs
+++ b/backends/candle/tests/test_dense.rs
@@ -62,11 +62,8 @@ fn test_stella_en_400m_v5_default_dense() -> Result<()> {
 #[test]
 #[serial_test::serial]
 fn test_stella_en_400m_v5_dense_768() -> Result<()> {
-    let (model_root, dense_paths) = download_artifacts(
-        "dunzhang/stella_en_400M_v5",
-        None,
-        Some("2_Dense_768"),
-    )?;
+    let (model_root, dense_paths) =
+        download_artifacts("dunzhang/stella_en_400M_v5", None, Some("2_Dense_768"))?;
     let tokenizer = load_tokenizer(&model_root)?;
 
     let backend = CandleBackend::new(

--- a/backends/candle/tests/test_gte.rs
+++ b/backends/candle/tests/test_gte.rs
@@ -164,9 +164,7 @@ fn test_gte_classification() -> Result<()> {
         vec![],
     );
 
-    let predictions: Vec<Vec<f32>> = backend
-        .predict(input_single)?.into_values()
-        .collect();
+    let predictions: Vec<Vec<f32>> = backend.predict(input_single)?.into_values().collect();
     let predictions_single = SnapshotScores::from(predictions);
 
     let matcher = relative_matcher();

--- a/backends/candle/tests/test_jina.rs
+++ b/backends/candle/tests/test_jina.rs
@@ -70,9 +70,7 @@ fn test_jina_rerank() -> Result<()> {
         vec![],
     );
 
-    let predictions: Vec<Vec<f32>> = backend
-        .predict(input_single)?.into_values()
-        .collect();
+    let predictions: Vec<Vec<f32>> = backend.predict(input_single)?.into_values().collect();
 
     let predictions = SnapshotScores::from(predictions);
     insta::assert_yaml_snapshot!("jinabert_reranker_single", predictions, &relative_matcher());

--- a/backends/candle/tests/test_modernbert.rs
+++ b/backends/candle/tests/test_modernbert.rs
@@ -194,9 +194,7 @@ fn test_modernbert_classification() -> Result<()> {
         vec![],
     );
 
-    let predictions: Vec<Vec<f32>> = backend
-        .predict(input_single)?.into_values()
-        .collect();
+    let predictions: Vec<Vec<f32>> = backend.predict(input_single)?.into_values().collect();
     let predictions_single = SnapshotScores::from(predictions);
 
     let matcher = relative_matcher();
@@ -231,9 +229,7 @@ fn test_modernbert_classification_mean_pooling() -> Result<()> {
         vec![],
     );
 
-    let predictions: Vec<Vec<f32>> = backend
-        .predict(input_single)?.into_values()
-        .collect();
+    let predictions: Vec<Vec<f32>> = backend.predict(input_single)?.into_values().collect();
     let predictions_single = SnapshotScores::from(predictions);
 
     let matcher = relative_matcher();


### PR DESCRIPTION
# What does this PR do?

This PR fixes `rustfmt` as it's failing on `main`, affecting some files under `backends/candle/tests/*.rs` due to some recent PR merges.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.