### PR TITLE
Skip Gemma3 tests when `HF_TOKEN` not set

### DIFF
--- a/backends/candle/tests/test_gemma3.rs
+++ b/backends/candle/tests/test_gemma3.rs
@@ -1,10 +1,12 @@
-mod common;
-
-use crate::common::{sort_embeddings, SnapshotEmbeddings};
 use anyhow::Result;
-use common::{batch, cosine_matcher, download_artifacts, load_tokenizer};
+
 use text_embeddings_backend_candle::CandleBackend;
 use text_embeddings_backend_core::{Backend, ModelType, Pool};
+
+mod common;
+use crate::common::{
+    batch, cosine_matcher, download_artifacts, load_tokenizer, sort_embeddings, SnapshotEmbeddings,
+};
 
 #[test]
 #[serial_test::serial]
@@ -14,7 +16,7 @@ fn test_gemma3() -> Result<()> {
     if std::env::var("HF_TOKEN").is_err()
         || std::env::var("HF_TOKEN").is_ok_and(|token| token.is_empty())
     {
-        println!("Skipping `test_gemma3` because `HF_TOKEN` is either not set or set empty.");
+        tracing::info!("Skipping `test_gemma3` because `HF_TOKEN` is either not set or set empty.");
         return Ok(());
     }
 


### PR DESCRIPTION
# What does this PR do?

This PR handles the `HF_TOKEN` environment variable to make sure that it's set and contains a non-empty string before running the Gemma3 tests, as otherwise the test will show as failing even if not totally true.

Note that this mainly affects contributors, as they won't get access to the `HF_TOKEN` secret when the workflow is automatically triggered, hence those tests will always fail otherwise.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [x] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.