### PR TITLE
feat: better prometheus buckets for batch_size, isl, and input length

### DIFF
--- a/router/src/prometheus.rs
+++ b/router/src/prometheus.rs
@@ -22,20 +22,33 @@ pub(crate) fn prometheus_builer(
         duration_buckets.push(value);
     }
 
-    // Input Length buckets
+    // Input Length buckets: half-steps up to 32k, then powers of 2
     let input_length_matcher = Matcher::Full(String::from("te_request_input_length"));
-    let input_length_buckets: Vec<f64> = (0..20)
-        .map(|x| 2.0_f64.powi(x))
-        .filter(|x| (*x as usize) <= max_input_length)
+    let input_length_buckets: Vec<f64> = [
+        1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 768.0, 1024.0, 1536.0, 2048.0,
+        3072.0, 4096.0, 6144.0, 8192.0, 12288.0, 16384.0, 24576.0, 32768.0, 65536.0, 131072.0,
+        262144.0, 524288.0,
+    ]
+    .into_iter()
+    .filter(|x| (*x as usize) <= max_input_length)
+    .collect();
+
+    // Batch size buckets: 1-32 (all integers), then powers of 2
+    let batch_size_matcher = Matcher::Full(String::from("te_batch_next_size"));
+    let batch_size_buckets: Vec<f64> = (1..=32)
+        .map(|x| x as f64)
+        .chain((7..13).map(|x| 2.0_f64.powi(x)))
         .collect();
 
-    // Batch size buckets
-    let batch_size_matcher = Matcher::Full(String::from("te_batch_next_size"));
-    let batch_size_buckets: Vec<f64> = (0..13).map(|x| 2.0_f64.powi(x)).collect();
-
-    // Batch tokens buckets
+    // Batch tokens buckets: half-steps up to 32k, then powers of 2
     let batch_tokens_matcher = Matcher::Full(String::from("te_batch_next_tokens"));
-    let batch_tokens_buckets: Vec<f64> = (0..21).map(|x| 2.0_f64.powi(x)).collect();
+    let batch_tokens_buckets: Vec<f64> = [
+        1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 768.0, 1024.0, 1536.0, 2048.0,
+        3072.0, 4096.0, 6144.0, 8192.0, 12288.0, 16384.0, 24576.0, 32768.0, 65536.0, 131072.0,
+        262144.0, 524288.0, 1048576.0,
+    ]
+    .into_iter()
+    .collect();
 
     // Prometheus handler
     PrometheusBuilder::new()


### PR DESCRIPTION
# What does this PR do?
I realized the prometheus metrics do some short-cuts where it could be helpful to have more information. Right now, buckets are bit generic and would benefit from some exta buckets. Most of the time batch size, and tokens are small, tokens by default often 8k or 16k, except for qwen models also 40k. Then for input-sequence-length, its in the same bucket. Potentially people release longer models, so the upper buckets are ok. I think this could help getting more visibility in load-distribution.

1. te_batch_next_size: 1, 2, 3, ..., 32, 64, 128, 256, 512, 1024, 2048, 4096
2. te_batch_next_tokens: Half-steps up to 32k, then powers of 2
   - 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 12288, 16384, 24576, 32768, 65536, 131072, ...
3. te_request_input_length: Same as tokens, but filtered by max_input_length

For batch_size:
- 1, 2, 3, ..., 32 (integers)
- 64, 128, 256, 512, 1024, 2048, 4096 (powers of 2 beyond 32)
For tokens (half-steps to 32k):
- Powers of 2: 1, 2, 4, 8, 16, 32, 64, 128, 256, 512
- Then half-steps: 768 (512+256), 1024, 1536 (1024+512), 2048, 3072 (2048+1024), 4096, 6144 (4096+2048), 8192, 12288 (8192+4096), 16384, 24576 (16384+8192), 32768
- Then powers of 2 beyond: 65536, 131072, 262144, 524288, 1048576

There is a limit on total number of metrics (times labels and buckets) which is around 750 for Baseten etc. I think we are still far below it. 

<!-- Remove if not applicable -->

Fixes # (issue)

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

@Narsil OR @alvarobartt

 -->
