### PR TITLE
Add dedicated linux/arm64 runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.job }}-${{matrix.name}}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     runs-on:
-      group: aws-highmemory-32-plus-priv
+      group: ${{ matrix.platform == 'linux/arm64' && 'aws-r8g-8xl-plus-nix' || 'aws-highmemory-32-plus-priv' }}
     permissions:
       contents: write
       packages: write
@@ -126,7 +126,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: ${{ matrix.platforms || 'linux/amd64' }}
+          platforms: ${{ matrix.platform || 'linux/amd64' }}
           build-args: |
             SCCACHE_GHA_ENABLED=${{ matrix.sccache }}
             CUDA_COMPUTE_CAP=${{ matrix.cudaComputeCap }}
@@ -168,7 +168,7 @@ jobs:
           target: grpc
           file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: ${{ matrix.platforms || 'linux/amd64' }}
+          platforms: ${{ matrix.platform || 'linux/amd64' }}
           build-args: |
             SCCACHE_GHA_ENABLED=${{ matrix.sccache }}
             CUDA_COMPUTE_CAP=${{ matrix.cudaComputeCap }}

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -69,7 +69,7 @@
     "runOn": "always",
     "sccache": true,
     "cudaComputeCap": 121,
-    "platforms": "linux/arm64",
+    "platform": "linux/arm64",
     "grpc": true,
     "dockerfile": "Dockerfile-cuda"
   },
@@ -94,7 +94,7 @@
     "imageNamePrefix": "cpu-arm64-",
     "runOn": "always",
     "sccache": true,
-    "platforms": "linux/arm64",
+    "platform": "linux/arm64",
     "grpc": true,
     "dockerfile": "Dockerfile-arm64"
   },


### PR DESCRIPTION
# What does this PR do?

This PR adds a dedicated `linux/arm64` runner to prevent QEMU emulation of `linux/arm64` from `linux/amd64`, as it's slower and it's leading to some consistency issues with the `sccache` when building `Dockerfile-cuda` with `CUDA_COMPUTE_CAP 121`.

Additionally, the platform emulation is slow, hence it's not ideal either, as the builds where taking ~1 hour more than on `linux/amd64` on both CPU and CUDA.

Thanks @glegendre01 for providing and configuring such runner!

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.