### PR TITLE
Add rate-limited and aggregate logging to reduce log volume at high load

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,26 @@ Options:
 
           [env: DISABLE_SPANS=]
 
+      --log-sample-rate <LOG_SAMPLE_RATE>
+          Maximum number of request success logs per second.
+
+          Set to 0 to disable request success logging entirely.
+          Set to a positive number to rate-limit request logs.
+          Default is 10 logs/second. Use --log-aggregate-interval to enable aggregate logging instead.
+
+          [env: LOG_SAMPLE_RATE=]
+          [default: 10]
+
+      --log-aggregate-interval <LOG_AGGREGATE_INTERVAL>
+          Interval in seconds for logging aggregate statistics.
+
+          Set to 0 to disable aggregate logging (default).
+          When set, aggregate stats will be logged at this interval instead of per-request logs.
+          Aggregate logs include request count, error count, characters processed, and tokens processed per interval.
+
+          [env: LOG_AGGREGATE_INTERVAL=]
+          [default: 0]
+
       --otlp-endpoint <OTLP_ENDPOINT>
           The grpc endpoint for opentelemetry. Telemetry is sent to this endpoint as OTLP over gRPC. e.g. `http://localhost:4317`
 
@@ -474,6 +494,67 @@ curl 127.0.0.1:8080/embed_sparse \
 
 `text-embeddings-inference` is instrumented with distributed tracing using OpenTelemetry. You can use this feature
 by setting the address to an OTLP collector with the `--otlp-endpoint` argument.
+
+### Logging Configuration
+
+At high load, logging every request can create excessive log volume, especially when using log aggregation solutions
+like Loki. TEI provides flexible logging controls to address this.
+
+#### Rate-Limited Request logging
+
+By default, TEI logs at most 10 request successes per second. You can adjust this limit:
+
+```shell
+# Log at most 5 request successes per second
+docker run --gpus all -p 8080:80 ghcr.io/huggingface/text-embeddings-inference:cuda-1.9 \
+    --model-id Qwen/Qwen3-Embedding-0.6B \
+    --log-sample-rate 5
+```
+
+To disable per-request success logging entirely:
+
+```shell
+# Disable individual request logging
+docker run --gpus all -p 8080:80 ghcr.io/huggingface/text-embeddings-inference:cuda-1.9 \
+    --model-id Qwen/Qwen3-Embedding-0.6B \
+    --log-sample-rate 0
+```
+
+#### Aggregate logging
+
+Instead of logging each individual request, you can opt for periodic aggregate statistics. This is recommended for
+production high-load deployments:
+
+```shell
+# Log aggregate statistics every 60 seconds
+docker run --gpus all -p 8080:80 ghcr.io/huggingface/text-embeddings-inference:cuda-1.9 \
+    --model-id Qwen/Qwen3-Embedding-0.6B \
+    --log-sample-rate 0 \
+    --log-aggregate-interval 60
+```
+
+This will produce logs like:
+```
+Request aggregate: 5234 requests (87.2/s), 12 errors | 10456789 chars (174280/s) | 2345678 tokens (39094/s)
+```
+
+#### Hybrid mode
+
+You can combine both approaches for balanced observability:
+
+```shell
+# Log up to 2 individual requests per second + aggregate stats every 30 seconds
+docker run --gpus all -p 8080:80 ghcr.io/huggingface/text-embeddings-inference:cuda-1.9 \
+    --model-id Qwen/Qwen3-Embedding-0.6B \
+    --log-sample-rate 2 \
+    --log-aggregate-interval 30
+```
+
+#### Environment variables
+
+Both options can also be configured via environment variables:
+- `LOG_SAMPLE_RATE` - Maximum request logs per second (default: 10)
+- `LOG_AGGREGATE_INTERVAL` - Aggregate logging interval in seconds (default: 0 = disabled)
 
 ### gRPC
 

--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -105,6 +105,8 @@ async fn predict(
     infer: Extension<Infer>,
     info: Extension<Info>,
     Extension(context): Extension<Option<opentelemetry::Context>>,
+    Extension(rate_limited_logger): Extension<Option<crate::RateLimitedLogger>>,
+    Extension(aggregate_logger): Extension<Option<crate::AggregateLogger>>,
     Json(req): Json<PredictRequest>,
 ) -> Result<(HeaderMap, Json<PredictResponse>), (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
@@ -274,7 +276,17 @@ async fn predict(
 
     let headers = HeaderMap::from(metadata);
 
-    tracing::info!("Success");
+    // Use rate-limited logger if available, otherwise use regular logging
+    if let Some(logger) = rate_limited_logger {
+        logger.try_log_success();
+    } else {
+        tracing::info!("Success");
+    }
+    
+    // Record success in aggregate logger if available
+    if let Some(agg_logger) = aggregate_logger {
+        agg_logger.record_success(metadata.compute_chars as u64, metadata.compute_tokens as u64);
+    }
 
     Ok((headers, Json(response)))
 }
@@ -308,6 +320,8 @@ async fn rerank(
     infer: Extension<Infer>,
     info: Extension<Info>,
     Extension(context): Extension<Option<opentelemetry::Context>>,
+    Extension(rate_limited_logger): Extension<Option<crate::RateLimitedLogger>>,
+    Extension(aggregate_logger): Extension<Option<crate::AggregateLogger>>,
     Json(req): Json<RerankRequest>,
 ) -> Result<(HeaderMap, Json<RerankResponse>), (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
@@ -468,7 +482,17 @@ async fn rerank(
 
     let headers = HeaderMap::from(metadata);
 
-    tracing::info!("Success");
+    // Use rate-limited logger if available, otherwise use regular logging
+    if let Some(logger) = rate_limited_logger {
+        logger.try_log_success();
+    } else {
+        tracing::info!("Success");
+    }
+    
+    // Record success in aggregate logger if available
+    if let Some(agg_logger) = aggregate_logger {
+        agg_logger.record_success(compute_chars as u64, total_compute_tokens as u64);
+    }
 
     Ok((headers, Json(response)))
 }
@@ -587,6 +611,8 @@ async fn embed(
     infer: Extension<Infer>,
     info: Extension<Info>,
     Extension(context): Extension<Option<opentelemetry::Context>>,
+    Extension(rate_limited_logger): Extension<Option<crate::RateLimitedLogger>>,
+    Extension(aggregate_logger): Extension<Option<crate::AggregateLogger>>,
     Json(req): Json<EmbedRequest>,
 ) -> Result<(HeaderMap, Json<EmbedResponse>), (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
@@ -734,7 +760,17 @@ async fn embed(
 
     let headers = HeaderMap::from(metadata);
 
-    tracing::info!("Success");
+    // Use rate-limited logger if available, otherwise use regular logging
+    if let Some(logger) = rate_limited_logger {
+        logger.try_log_success();
+    } else {
+        tracing::info!("Success");
+    }
+    
+    // Record success in aggregate logger if available
+    if let Some(agg_logger) = aggregate_logger {
+        agg_logger.record_success(metadata.compute_chars as u64, metadata.compute_tokens as u64);
+    }
 
     Ok((headers, Json(response)))
 }
@@ -767,6 +803,8 @@ async fn embed_sparse(
     infer: Extension<Infer>,
     info: Extension<Info>,
     Extension(context): Extension<Option<opentelemetry::Context>>,
+    Extension(rate_limited_logger): Extension<Option<crate::RateLimitedLogger>>,
+    Extension(aggregate_logger): Extension<Option<crate::AggregateLogger>>,
     Json(req): Json<EmbedSparseRequest>,
 ) -> Result<(HeaderMap, Json<EmbedSparseResponse>), (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
@@ -920,7 +958,17 @@ async fn embed_sparse(
 
     let headers = HeaderMap::from(metadata);
 
-    tracing::info!("Success");
+    // Use rate-limited logger if available, otherwise use regular logging
+    if let Some(logger) = rate_limited_logger {
+        logger.try_log_success();
+    } else {
+        tracing::info!("Success");
+    }
+    
+    // Record success in aggregate logger if available
+    if let Some(agg_logger) = aggregate_logger {
+        agg_logger.record_success(metadata.compute_chars as u64, metadata.compute_tokens as u64);
+    }
 
     Ok((headers, Json(response)))
 }
@@ -954,6 +1002,8 @@ async fn embed_all(
     infer: Extension<Infer>,
     info: Extension<Info>,
     Extension(context): Extension<Option<opentelemetry::Context>>,
+    Extension(rate_limited_logger): Extension<Option<crate::RateLimitedLogger>>,
+    Extension(aggregate_logger): Extension<Option<crate::AggregateLogger>>,
     Json(req): Json<EmbedAllRequest>,
 ) -> Result<(HeaderMap, Json<EmbedAllResponse>), (StatusCode, Json<ErrorResponse>)> {
     let span = tracing::Span::current();
@@ -1097,7 +1147,17 @@ async fn embed_all(
 
     let headers = HeaderMap::from(metadata);
 
-    tracing::info!("Success");
+    // Use rate-limited logger if available, otherwise use regular logging
+    if let Some(logger) = rate_limited_logger {
+        logger.try_log_success();
+    } else {
+        tracing::info!("Success");
+    }
+    
+    // Record success in aggregate logger if available
+    if let Some(agg_logger) = aggregate_logger {
+        agg_logger.record_success(compute_chars as u64, total_compute_tokens as u64);
+    }
 
     Ok((headers, Json(response)))
 }
@@ -1130,6 +1190,8 @@ async fn openai_embed(
     infer: Extension<Infer>,
     info: Extension<Info>,
     Extension(context): Extension<Option<opentelemetry::Context>>,
+    Extension(rate_limited_logger): Extension<Option<crate::RateLimitedLogger>>,
+    Extension(aggregate_logger): Extension<Option<crate::AggregateLogger>>,
     Json(req): Json<OpenAICompatRequest>,
 ) -> Result<(HeaderMap, Json<OpenAICompatResponse>), (StatusCode, Json<OpenAICompatErrorResponse>)>
 {
@@ -1315,7 +1377,17 @@ async fn openai_embed(
     let compute_tokens = metadata.compute_tokens;
     let headers = HeaderMap::from(metadata);
 
-    tracing::info!("Success");
+    // Use rate-limited logger if available, otherwise use regular logging
+    if let Some(logger) = rate_limited_logger {
+        logger.try_log_success();
+    } else {
+        tracing::info!("Success");
+    }
+    
+    // Record success in aggregate logger if available
+    if let Some(agg_logger) = aggregate_logger {
+        agg_logger.record_success(metadata.compute_chars as u64, metadata.compute_tokens as u64);
+    }
 
     let response = OpenAICompatResponse {
         object: "list",
@@ -1632,6 +1704,9 @@ pub async fn run(
     payload_limit: usize,
     api_key: Option<String>,
     cors_allow_origin: Option<Vec<String>>,
+    rate_limited_logger: Option<crate::RateLimitedLogger>,
+    aggregate_logger: Option<crate::AggregateLogger>,
+    log_aggregate_interval: u64,
 ) -> Result<(), anyhow::Error> {
     // OpenAPI documentation
     #[derive(OpenApi)]
@@ -1865,12 +1940,22 @@ pub async fn run(
         .layer(Extension(infer))
         .layer(Extension(info))
         .layer(Extension(prom_handle.clone()))
+        .layer(Extension(rate_limited_logger))
+        .layer(Extension(aggregate_logger))
         .layer(OtelAxumLayer::default())
         .layer(axum::middleware::from_fn(
             logging::http::trace_context_middleware,
         ))
         .layer(DefaultBodyLimit::max(payload_limit))
         .layer(cors_layer);
+
+    // Spawn aggregate logger task
+    if let (Some(agg_logger), interval) = (aggregate_logger.clone(), log_aggregate_interval) {
+        if interval > 0 {
+            crate::spawn_aggregate_logger_task(agg_logger, interval);
+            tracing::info!("Aggregate logger task spawned with interval: {} seconds", interval);
+        }
+    }
 
     // Run server
     let listener = tokio::net::TcpListener::bind(&addr)

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -38,6 +38,7 @@ use tokenizers::{PostProcessorWrapper, Tokenizer};
 use tracing::Span;
 
 pub use logging::init_logging;
+pub use logging::{RateLimitedLogger, AggregateLogger, spawn_aggregate_logger_task};
 
 /// Create entrypoint
 #[allow(clippy::too_many_arguments)]
@@ -67,6 +68,9 @@ pub async fn run(
     otlp_service_name: String,
     prometheus_port: u16,
     cors_allow_origin: Option<Vec<String>>,
+    rate_limited_logger: Option<RateLimitedLogger>,
+    aggregate_logger: Option<AggregateLogger>,
+    log_aggregate_interval: u64,
 ) -> Result<()> {
     let model_id_path = Path::new(&model_id);
     let (model_root, api_repo) = if model_id_path.exists() && model_id_path.is_dir() {
@@ -377,6 +381,9 @@ pub async fn run(
             payload_limit,
             api_key,
             cors_allow_origin,
+            rate_limited_logger,
+            aggregate_logger,
+            log_aggregate_interval,
         )
         .await
     }

--- a/router/src/logging.rs
+++ b/router/src/logging.rs
@@ -7,6 +7,11 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
 #[cfg(feature = "http")]
 pub mod http {
     use axum::{extract::Request, middleware::Next, response::Response};
@@ -66,15 +71,197 @@ pub mod http {
     }
 }
 
+/// Rate-limited logger for request success messages
+/// Prevents logging every single request at high load
+#[derive(Clone)]
+pub struct RateLimitedLogger {
+    /// Maximum number of request logs per interval
+    max_logs_per_interval: u64,
+    /// Counter for current interval
+    counter: Arc<AtomicU64>,
+    /// When the current interval started
+    interval_start: Arc<Mutex<Instant>>,
+    /// Length of each interval
+    interval_duration: Duration,
+}
+
+impl RateLimitedLogger {
+    pub fn new(max_logs_per_second: u64) -> Self {
+        Self {
+            max_logs_per_interval: max_logs_per_second,
+            counter: Arc::new(AtomicU64::new(0)),
+            interval_start: Arc::new(Mutex::new(Instant::now())),
+            interval_duration: Duration::from_secs(1),
+        }
+    }
+
+    /// Try to log a success message. Returns true if the log was emitted,
+    /// false if it was rate-limited
+    pub fn try_log_success(&self) -> bool {
+        let now = Instant::now();
+
+        // Check if we need to reset the counter for a new interval
+        {
+            let mut start = self.interval_start.lock().unwrap();
+            if now.duration_since(*start) >= self.interval_duration {
+                // Reset for new interval
+                self.counter.store(0, Ordering::Relaxed);
+                *start = now;
+            }
+        }
+
+        // Increment counter and check if we should log
+        let count = self.counter.fetch_add(1, Ordering::Relaxed);
+        if count < self.max_logs_per_interval {
+            tracing::info!("Success");
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get the current count of logged requests in this interval
+    pub fn get_count(&self) -> u64 {
+        self.counter.load(Ordering::Relaxed)
+    }
+}
+
+/// Aggregate statistics tracker for request metrics
+#[derive(Clone)]
+pub struct AggregateLogger {
+    /// Total success count
+    success_count: Arc<AtomicU64>,
+    /// Total error count
+    error_count: Arc<AtomicU64>,
+    /// Total compute characters processed
+    compute_chars: Arc<AtomicU64>,
+    /// Total tokens processed
+    total_tokens: Arc<AtomicU64>,
+    /// When the logger was started
+    start_time: Arc<Mutex<Instant>>,
+    /// Whether the logger is active
+    active: Arc<Mutex<bool>>,
+}
+
+impl AggregateLogger {
+    pub fn new() -> Self {
+        Self {
+            success_count: Arc::new(AtomicU64::new(0)),
+            error_count: Arc::new(AtomicU64::new(0)),
+            compute_chars: Arc::new(AtomicU64::new(0)),
+            total_tokens: Arc::new(AtomicU64::new(0)),
+            start_time: Arc::new(Mutex::new(Instant::now())),
+            active: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    /// Start the aggregate logger
+    pub fn start(&self) {
+        let mut active = self.active.lock().unwrap();
+        *active = true;
+        let mut start_time = self.start_time.lock().unwrap();
+        *start_time = Instant::now();
+    }
+
+    /// Stop the aggregate logger
+    pub fn stop(&self) {
+        let mut active = self.active.lock().unwrap();
+        *active = false;
+    }
+
+    /// Record a successful request
+    pub fn record_success(&self, chars: u64, tokens: u64) {
+        if *self.active.lock().unwrap() {
+            self.success_count.fetch_add(1, Ordering::Relaxed);
+            self.compute_chars.fetch_add(chars, Ordering::Relaxed);
+            self.total_tokens.fetch_add(tokens, Ordering::Relaxed);
+        }
+    }
+
+    /// Record an error
+    pub fn record_error(&self) {
+        if *self.active.lock().unwrap() {
+            self.error_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Get and reset the current stats
+    pub fn get_and_reset_stats(&self) -> AggregateStats {
+        let success = self.success_count.swap(0, Ordering::Relaxed);
+        let errors = self.error_count.swap(0, Ordering::Relaxed);
+        let chars = self.compute_chars.swap(0, Ordering::Relaxed);
+        let tokens = self.total_tokens.swap(0, Ordering::Relaxed);
+
+        let elapsed = {
+            let mut start_time = self.start_time.lock().unwrap();
+            let elapsed = start_time.elapsed();
+            *start_time = Instant::now();
+            elapsed
+        };
+
+        AggregateStats {
+            success_count: success,
+            error_count: errors,
+            compute_chars: chars,
+            total_tokens: tokens,
+            elapsed,
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        *self.active.lock().unwrap()
+    }
+}
+
+impl Default for AggregateLogger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Aggregate statistics snapshot
+pub struct AggregateStats {
+    pub success_count: u64,
+    pub error_count: u64,
+    pub compute_chars: u64,
+    pub total_tokens: u64,
+    pub elapsed: Duration,
+}
+
+impl std::fmt::Display for AggregateStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let secs = self.elapsed.as_secs_f64().max(0.001);
+        let req_per_sec = self.success_count as f64 / secs;
+        let chars_per_sec = self.compute_chars as f64 / secs;
+        let tokens_per_sec = self.total_tokens as f64 / secs;
+
+        write!(
+            f,
+            "Request aggregate: {} requests ({:.1}/s), {} errors | {} chars ({:.0}/s) | {} tokens ({:.0}/s)",
+            self.success_count,
+            req_per_sec,
+            self.error_count,
+            self.compute_chars,
+            chars_per_sec,
+            self.total_tokens,
+            tokens_per_sec
+        )
+    }
+}
+
 /// Init logging using env variables LOG_LEVEL and LOG_FORMAT:
 ///     - otlp_endpoint is an optional URL to an Open Telemetry collector
 ///     - LOG_LEVEL may be TRACE, DEBUG, INFO, WARN or ERROR (default to INFO)
+/// 
+/// Returns: (global_tracer, rate_limited_logger, aggregate_logger)
 pub fn init_logging(
     otlp_endpoint: Option<&String>,
     otlp_service_name: String,
     json_output: bool,
     disable_spans: bool,
-) -> bool {
+    log_sample_rate: u64,
+    log_aggregate_interval: u64,
+) -> (bool, Option<RateLimitedLogger>, Option<AggregateLogger>) {
     let mut layers = Vec::new();
 
     // STDOUT/STDERR layer
@@ -130,5 +317,46 @@ pub fn init_logging(
         .with(env_filter)
         .with(layers)
         .init();
-    global_tracer
+
+    // Initialize rate-limited logger if sample rate > 0
+    let rate_limited_logger = if log_sample_rate > 0 {
+        Some(RateLimitedLogger::new(log_sample_rate))
+    } else {
+        None
+    };
+
+    // Initialize aggregate logger if interval > 0
+    let aggregate_logger = if log_aggregate_interval > 0 {
+        let agg_logger = AggregateLogger::new();
+        agg_logger.start();
+        Some(agg_logger)
+    } else {
+        None
+    };
+
+    (global_tracer, rate_limited_logger, aggregate_logger)
+}
+
+/// Spawn a background task to log aggregate statistics at regular intervals
+pub fn spawn_aggregate_logger_task(
+    aggregate_logger: AggregateLogger,
+    interval_secs: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let interval = Duration::from_secs(interval_secs);
+        let mut interval_timer = tokio::time::interval(interval);
+        
+        // Skip the first tick (waits for the full interval)
+        interval_timer.tick().await;
+        
+        loop {
+            interval_timer.tick().await;
+            if aggregate_logger.is_active() {
+                let stats = aggregate_logger.get_and_reset_stats();
+                if stats.success_count > 0 || stats.error_count > 0 {
+                    tracing::info!("{}", stats);
+                }
+            }
+        }
+    })
 }

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -181,6 +181,19 @@ struct Args {
     #[clap(long, env)]
     disable_spans: bool,
 
+    /// Maximum number of request success logs per second.
+    /// Set to 0 to disable request success logging entirely.
+    /// Set to a positive number to rate-limit request logs.
+    /// Default is 10 logs/second. Use --log-aggregate-interval to enable aggregate logging instead.
+    #[clap(long, env, default_value = "10")]
+    log_sample_rate: u64,
+
+    /// Interval in seconds for logging aggregate statistics.
+    /// Set to 0 to disable aggregate logging (default).
+    /// When set, aggregate stats will be logged at this interval instead of per-request logs.
+    #[clap(long, env, default_value = "0")]
+    log_aggregate_interval: u64,
+
     /// The grpc endpoint for opentelemetry. Telemetry is sent to this endpoint as OTLP over gRPC.
     /// e.g. `http://localhost:4317`
     #[clap(long, env)]
@@ -206,12 +219,15 @@ async fn main() -> Result<()> {
     let args: Args = Args::parse();
 
     // Initialize logging and telemetry
-    let global_tracer = text_embeddings_router::init_logging(
-        args.otlp_endpoint.as_ref(),
-        args.otlp_service_name.clone(),
-        args.json_output,
-        args.disable_spans,
-    );
+    let (global_tracer, rate_limited_logger, aggregate_logger) =
+        text_embeddings_router::init_logging(
+            args.otlp_endpoint.as_ref(),
+            args.otlp_service_name.clone(),
+            args.json_output,
+            args.disable_spans,
+            args.log_sample_rate,
+            args.log_aggregate_interval,
+        );
 
     tracing::info!("{args:?}");
 
@@ -266,6 +282,9 @@ async fn main() -> Result<()> {
         args.otlp_service_name,
         args.prometheus_port,
         args.cors_allow_origin,
+        rate_limited_logger,
+        aggregate_logger,
+        args.log_aggregate_interval,
     )
     .await?;
 


### PR DESCRIPTION
## Summary

At high load, logging every request can be overwhelming for logging solutions like Loki. This PR introduces two new CLI arguments to provide flexible logging controls:

### New CLI Arguments

- **`--log-sample-rate`**: Controls maximum request success logs per second (default: 10, set to 0 to disable per-request logging)
- **`--log-aggregate-interval`**: Interval in seconds for logging aggregate statistics (default: 0 = disabled)

### Features

**Rate-Limited Logger**
- Limits per-request success logs to a maximum number per second
- Prevents log flooding during traffic spikes
- Backward compatible (defaults to 10 logs/sec)

**Aggregate Logger**  
- Tracks request statistics and logs aggregated summaries at regular intervals
- Provides periodic summaries like:
  ```
  Request aggregate: 5234 requests (87.2/s), 12 errors | 10456789 chars (174280/s) | 2345678 tokens (39094/s)
  ```
- Includes request count, error count, characters processed, and tokens processed per interval

### Usage Examples

```bash
# Disable per-request logging, use aggregate logging every 60 seconds
text-embeddings-router --model-id model --log-sample-rate 0 --log-aggregate-interval 60

# Hybrid: max 2 individual logs/sec + aggregate stats every 30 seconds
text-embeddings-router --model-id model --log-sample-rate 2 --log-aggregate-interval 30
```

Both options can also be configured via environment variables:
- `LOG_SAMPLE_RATE` (default: 10)
- `LOG_AGGREGATE_INTERVAL` (default: 0)

### Files Changed

- `router/src/logging.rs` - Added RateLimitedLogger and AggregateLogger implementations
- `router/src/main.rs` - Added CLI arguments
- `router/src/lib.rs` - Updated run() signature to pass loggers  
- `router/src/http/server.rs` - Updated all 6 endpoint handlers to use new loggers
- `README.md` - Added comprehensive documentation for the new features

### Benefits

✅ Reduces logging overhead at high load
✅ Provides better observability through aggregate statistics  
✅ Backward compatible - defaults similar to current behavior
✅ Works seamlessly with Loki and other log aggregation solutions
✅ Configurable via CLI args or environment variables