### PR TITLE
fix(docker): detect CUDA version from `CUDA UMD Version` header on driver 6xx (#870)

### DIFF
--- a/cuda-entrypoint.sh
+++ b/cuda-entrypoint.sh
@@ -10,7 +10,10 @@ fi
 # version is lower than that; whilst we shouldn't include that when CUDA is 13.0+
 # as otherwise it will fail due to it.
 if [ -d /usr/local/cuda/compat ]; then
-    DRIVER_CUDA=$(nvidia-smi 2>/dev/null | awk '/CUDA Version/ {print $3; exit}')
+    # Match both the classic `CUDA Version:` banner and the driver-6xx
+    # `CUDA UMD Version:` rename, and extract the version number itself
+    # (the old `awk '{print $3}'` returned the NVIDIA-SMI version, not CUDA).
+    DRIVER_CUDA=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA( UMD)? Version:[[:space:]]*[0-9]+(\.[0-9]+)+' | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
 
     IFS='.' read -r MAJ MIN PATCH <<EOF
 ${DRIVER_CUDA:-0.0.0}

--- a/cuda-entrypoint.sh
+++ b/cuda-entrypoint.sh
@@ -10,11 +10,8 @@ fi
 # version is lower than that; whilst we shouldn't include that when CUDA is 13.0+
 # as otherwise it will fail due to it.
 if [ -d /usr/local/cuda/compat ]; then
-    # Match the classic `CUDA Version:` banner, the driver-6xx `CUDA UMD
-    # Version:` rename, and any future `CUDA <word> Version:` variant, then
-    # extract the version number itself (the old `awk '{print $3}'` returned
-    # the NVIDIA-SMI version, not CUDA).
-    DRIVER_CUDA=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA[[:space:]]+([A-Za-z]+[[:space:]]+)?Version:[[:space:]]*[0-9]+(\.[0-9]+)+' | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
+    # Match both "CUDA Version" and "CUDA UMD Version" (on `driver-6xx` onwards)
+    DRIVER_CUDA=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA[[:space:]]+([A-Za-z]+[[:space:]])?Version:[[:space:]]*[0-9]+(\.[0-9]+)+' | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
 
     IFS='.' read -r MAJ MIN PATCH <<EOF
 ${DRIVER_CUDA:-0.0.0}

--- a/cuda-entrypoint.sh
+++ b/cuda-entrypoint.sh
@@ -10,10 +10,11 @@ fi
 # version is lower than that; whilst we shouldn't include that when CUDA is 13.0+
 # as otherwise it will fail due to it.
 if [ -d /usr/local/cuda/compat ]; then
-    # Match both the classic `CUDA Version:` banner and the driver-6xx
-    # `CUDA UMD Version:` rename, and extract the version number itself
-    # (the old `awk '{print $3}'` returned the NVIDIA-SMI version, not CUDA).
-    DRIVER_CUDA=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA( UMD)? Version:[[:space:]]*[0-9]+(\.[0-9]+)+' | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
+    # Match the classic `CUDA Version:` banner, the driver-6xx `CUDA UMD
+    # Version:` rename, and any future `CUDA <word> Version:` variant, then
+    # extract the version number itself (the old `awk '{print $3}'` returned
+    # the NVIDIA-SMI version, not CUDA).
+    DRIVER_CUDA=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA[[:space:]]+([A-Za-z]+[[:space:]]+)?Version:[[:space:]]*[0-9]+(\.[0-9]+)+' | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
 
     IFS='.' read -r MAJ MIN PATCH <<EOF
 ${DRIVER_CUDA:-0.0.0}


### PR DESCRIPTION
## Problem

On hosts with the **driver-6xx series**, TEI silently runs on **CPU** even with `--gpus all` and a healthy GPU.

`cuda-entrypoint.sh` (added in #831) decides whether to prepend `/usr/local/cuda/compat` to `LD_LIBRARY_PATH` based on the host CUDA version, detected via:

```bash
DRIVER_CUDA=$(nvidia-smi 2>/dev/null | awk '/CUDA Version/ {print $3; exit}')
```

This has two problems:

1. **Wrong field.** On the classic banner `| NVIDIA-SMI 535.104.05  Driver Version: 535.104.05  CUDA Version: 12.2 |`, `$3` is the **NVIDIA-SMI version** (`535.104.05`), not the CUDA version.
2. **Header rename (the reported regression).** Driver 6xx renamed the banner field `CUDA Version:` → `CUDA UMD Version:`, so `/CUDA Version/` matches nothing → `DRIVER_CUDA` is empty → defaults to `0.0.0` → classified as pre-12.9.1 → `cuda-compat-12-9` (`libcuda.so.575.*`) is prepended. On a CUDA 13 / driver-6xx host that shim can't bind the new KMD ABI, so `cuDeviceGetCount` returns `CUDA_ERROR_NO_DEVICE` and candle/cudarc falls back to CPU.

## Fix

Extract the **version number itself**, matching both the classic and the new UMD header:

```bash
DRIVER_CUDA=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA( UMD)? Version:[[:space:]]*[0-9]+(\.[0-9]+)+' | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
```

## Verification (end-to-end simulation of the full gate)

| host banner | detected | compat decision |
|---|---|---|
| `CUDA UMD Version: 13.3` (driver 6xx) | `13.3` | **skipped → GPU works** ✅ (was: empty→added→CPU) |
| `CUDA Version: 12.2` | `12.2` | added (correct, < 12.9.1) |
| `CUDA Version: 13.0` | `13.0` | skipped (correct) |
| no CUDA line | `<empty>` | added (unchanged fallback) |

Note this also corrects case (1): genuine CUDA `< 12.9.1` hosts now actually receive the compat shim as the NOTE comment intends (previously the `$3` bug read the driver version, so it was effectively never added). Happy to gate that behind a more conservative path if you'd prefer to scope this strictly to the driver-6xx regression.

`bash -n cuda-entrypoint.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
