### PR TITLE
support b300

### DIFF
--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -55,6 +55,15 @@
     "dockerfile": "Dockerfile-cuda"
   },
   {
+    "name": "blackwell-103",
+    "imageNamePrefix": "103-",
+    "runOn": "always",
+    "sccache": true,
+    "cudaComputeCap": 103,
+    "grpc": true,
+    "dockerfile": "Dockerfile-cuda"
+  },
+  {
     "name": "blackwell-120",
     "imageNamePrefix": "120-",
     "runOn": "always",

--- a/Dockerfile-cuda
+++ b/Dockerfile-cuda
@@ -5,6 +5,7 @@ ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 ENV PATH="/root/.cargo/bin:${PATH}"
 # aligned with `cargo-chef` version in `lukemathwalker/cargo-chef:latest-rust-1.92-bookworm`
 ENV CARGO_CHEF=0.1.73
+ENV RUST_VERSION=1.85.1
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
@@ -23,7 +24,7 @@ RUN case "${TARGETARCH}" in \
     chmod +x /usr/local/bin/sccache
 
 COPY rust-toolchain.toml rust-toolchain.toml
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal --default-toolchain $RUST_VERSION
 RUN cargo install cargo-chef --version $CARGO_CHEF --locked
 
 FROM base-builder AS planner
@@ -68,6 +69,9 @@ RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
     elif [ ${CUDA_COMPUTE_CAP} -eq 100 ]; \
     then  \
     nvprune --generate-code code=sm_100 /usr/local/cuda/lib64/libcublas_static.a -o /usr/local/cuda/lib64/libcublas_static.a; \
+    elif [ ${CUDA_COMPUTE_CAP} -eq 103 ]; \
+    then  \
+    nvprune --generate-code code=sm_100 --generate-code code=sm_103 /usr/local/cuda/lib64/libcublas_static.a -o /usr/local/cuda/lib64/libcublas_static.a; \
     elif [ ${CUDA_COMPUTE_CAP} -eq 120 ]; \
     then  \
     nvprune --generate-code code=sm_120 /usr/local/cuda/lib64/libcublas_static.a -o /usr/local/cuda/lib64/libcublas_static.a; \

--- a/Dockerfile-cuda-all
+++ b/Dockerfile-cuda-all
@@ -5,6 +5,7 @@ ENV RUSTC_WRAPPER=/usr/local/bin/sccache
 ENV PATH="/root/.cargo/bin:${PATH}"
 # aligned with `cargo-chef` version in `lukemathwalker/cargo-chef:latest-rust-1.92-bookworm`
 ENV CARGO_CHEF=0.1.73
+ENV RUST_VERSION=1.85.1
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     curl \
@@ -17,7 +18,7 @@ RUN curl -fsSL https://github.com/mozilla/sccache/releases/download/v$SCCACHE/sc
     chmod +x /usr/local/bin/sccache
 
 COPY rust-toolchain.toml rust-toolchain.toml
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal --default-toolchain $RUST_VERSION
 RUN cargo install cargo-chef --version $CARGO_CHEF --locked
 
 FROM base-builder AS planner
@@ -63,11 +64,19 @@ RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
 
 RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
     --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=89 cargo chef cook --release --features candle-cuda --recipe-path recipe.json && sccache -s;
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
     CUDA_COMPUTE_CAP=90 cargo chef cook --release --features candle-cuda --recipe-path recipe.json && sccache -s;
 
 RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
     --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
     CUDA_COMPUTE_CAP=100 cargo chef cook --release --features candle-cuda --recipe-path recipe.json && sccache -s;
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=103 cargo chef cook --release --features candle-cuda --recipe-path recipe.json && sccache -s;
 
 RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
     --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
@@ -93,6 +102,12 @@ RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/te
 
 RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
     --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=89 cargo build --release --bin text-embeddings-router -F candle-cuda && sccache -s;
+
+RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-89
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
     CUDA_COMPUTE_CAP=90 cargo build --release --bin text-embeddings-router -F candle-cuda && sccache -s;
 
 RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-90
@@ -102,6 +117,13 @@ RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
     CUDA_COMPUTE_CAP=100 cargo build --release --bin text-embeddings-router -F candle-cuda && sccache -s;
 
 RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-100
+
+RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
+    --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
+    CUDA_COMPUTE_CAP=103 cargo build --release --bin text-embeddings-router -F candle-cuda && sccache -s;
+
+RUN mv /usr/src/target/release/text-embeddings-router /usr/src/target/release/text-embeddings-router-103
+
 
 RUN --mount=type=secret,id=actions_results_url,env=ACTIONS_RESULTS_URL \
     --mount=type=secret,id=actions_runtime_token,env=ACTIONS_RUNTIME_TOKEN \
@@ -127,8 +149,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 
 COPY --from=builder /usr/src/target/release/text-embeddings-router-75 /usr/local/bin/text-embeddings-router-75
 COPY --from=builder /usr/src/target/release/text-embeddings-router-80 /usr/local/bin/text-embeddings-router-80
+COPY --from=builder /usr/src/target/release/text-embeddings-router-89 /usr/local/bin/text-embeddings-router-89
 COPY --from=builder /usr/src/target/release/text-embeddings-router-90 /usr/local/bin/text-embeddings-router-90
 COPY --from=builder /usr/src/target/release/text-embeddings-router-100 /usr/local/bin/text-embeddings-router-100
+COPY --from=builder /usr/src/target/release/text-embeddings-router-103 /usr/local/bin/text-embeddings-router-103
 COPY --from=builder /usr/src/target/release/text-embeddings-router-120 /usr/local/bin/text-embeddings-router-120
 
 COPY --chmod=775 cuda-all-entrypoint.sh entrypoint.sh

--- a/backends/candle/src/compute_cap.rs
+++ b/backends/candle/src/compute_cap.rs
@@ -31,6 +31,8 @@ fn compute_cap_matching(runtime_compute_cap: usize, compile_compute_cap: usize) 
         (89, 89) => true,
         (90, 90) => true,
         (100, 100) => true,
+        (100..=103, 100) => true,
+        (103, 103) => true,
         (120..=121, 120) => true,
         (121, 121) => true,
         (_, _) => false,
@@ -57,6 +59,10 @@ mod tests {
         assert!(compute_cap_matching(86, 86));
         assert!(compute_cap_matching(89, 89));
         assert!(compute_cap_matching(90, 90));
+        assert!(compute_cap_matching(89, 86));
+        assert!(compute_cap_matching(100, 100));
+        assert!(compute_cap_matching(103, 100));
+        assert!(compute_cap_matching(103, 103));
         assert!(compute_cap_matching(120, 120));
         assert!(compute_cap_matching(121, 121));
         assert!(compute_cap_matching(121, 120));
@@ -92,6 +98,12 @@ mod tests {
         assert!(!compute_cap_matching(100, 86));
         assert!(!compute_cap_matching(100, 89));
         assert!(!compute_cap_matching(100, 90));
+
+        assert!(!compute_cap_matching(103, 75));
+        assert!(!compute_cap_matching(103, 80));
+        assert!(!compute_cap_matching(103, 86));
+        assert!(!compute_cap_matching(103, 89));
+        assert!(!compute_cap_matching(103, 90));
 
         assert!(!compute_cap_matching(120, 75));
         assert!(!compute_cap_matching(120, 80));

--- a/backends/candle/src/flash_attn.rs
+++ b/backends/candle/src/flash_attn.rs
@@ -64,6 +64,7 @@ pub(crate) fn flash_attn_varlen(
     } else if (80..90).contains(&runtime_compute_cap)
         || runtime_compute_cap == 90
         || runtime_compute_cap == 100
+        || runtime_compute_cap == 103
         || runtime_compute_cap == 120
         || runtime_compute_cap == 121
     {

--- a/cuda-all-entrypoint.sh
+++ b/cuda-all-entrypoint.sh
@@ -36,6 +36,8 @@ elif [ ${compute_cap} -eq 90 ]; then
     exec text-embeddings-router-90 "$@"
 elif [ ${compute_cap} -eq 100 ]; then
     exec text-embeddings-router-100 "$@"
+elif [ ${compute_cap} -eq 103 ]; then
+    exec text-embeddings-router-103 "$@"
 elif [ ${compute_cap} -eq 120 ]; then
     exec text-embeddings-router-120 "$@"
 else


### PR DESCRIPTION

## What does this PR do?

This PR adds support for running Text Embeddings Inference (TEI) on NVIDIA B300 GPUs.

The main changes focus on enabling the correct CUDA architecture targeting for the B300 platform by updating both the build environment and FlashAttention compilation configuration.

### Changes included
Update Docker build configuration to support B300 CUDA compute capability.
Extend FlashAttention build settings to include B300-compatible compute capability targets.
Ensure TEI images can be built and executed correctly on B300 environments.
Keep existing GPU architecture support unchanged for backward compatibility.

### Motivation

Current TEI build artifacts and dependencies are configured for existing supported GPU architectures and do not include the compute capability required by NVIDIA B300 GPUs.

Without these changes:

Docker images may not compile optimized kernels for B300.
FlashAttention kernels may fail to build or run suboptimally.
TEI deployment on B300 hardware is not fully supported.

This PR enables TEI users to build and deploy inference workloads on B300 while preserving compatibility with existing GPU targets.