### PR TITLE
Fix `max_position_embeddings` handling in `NomicBertConfig` and `FlashNomicBertConfig`

### DIFF
--- a/backends/candle/src/models/flash_nomic.rs
+++ b/backends/candle/src/models/flash_nomic.rs
@@ -233,13 +233,9 @@ impl FlashNomicBertModel {
         let embeddings = NomicBertEmbeddings::load(vb.clone(), config)?;
         let encoder = NomicBertEncoder::load(vb.pp("encoder"), config)?;
 
-        let max_position_embeddings = match config.max_position_embeddings {
-            Some(max_position_embeddings) => max_position_embeddings,
-            None => match config.max_trained_positions {
-                Some(max_trained_positions) => max_trained_positions,
-                None => 2048,
-            },
-        };
+        let max_position_embeddings = config
+            .max_position_embeddings
+            .unwrap_or(config.max_trained_positions.unwrap_or(2048));
 
         let rotary_dim = encoder.layers[0].attention.attention_head_size;
         let inv_freqs = get_inv_freqs(rotary_dim, config.rotary_emb_base, vb.device(), None)?;

--- a/backends/candle/src/models/flash_nomic.rs
+++ b/backends/candle/src/models/flash_nomic.rs
@@ -196,7 +196,7 @@ pub struct FlashNomicBertModel {
     pool: Pool,
     pub device: Device,
 
-    max_trained_positions: u32,
+    max_position_embeddings: u32,
     rotary_cache: (Tensor, Tensor),
     scaled_rotary_cache: Option<(Tensor, Tensor)>,
 
@@ -233,14 +233,21 @@ impl FlashNomicBertModel {
         let embeddings = NomicBertEmbeddings::load(vb.clone(), config)?;
         let encoder = NomicBertEncoder::load(vb.pp("encoder"), config)?;
 
+        let max_position_embeddings = match config.max_position_embeddings {
+            Some(max_position_embeddings) => max_position_embeddings,
+            None => match config.max_trained_positions {
+                Some(max_trained_positions) => max_trained_positions,
+                None => 2048,
+            },
+        };
+
         let rotary_dim = encoder.layers[0].attention.attention_head_size;
         let inv_freqs = get_inv_freqs(rotary_dim, config.rotary_emb_base, vb.device(), None)?;
         let rotary_cache = get_cos_sin(config.n_positions, &inv_freqs, vb.dtype(), false)?;
 
         let scaled_rotary_cache = if let Some(scaling_factor) = config.rotary_scaling_factor {
             let new_base = (config.rotary_emb_base
-                * ((scaling_factor * config.n_positions as f32
-                    / config.max_trained_positions as f32)
+                * ((scaling_factor * config.n_positions as f32 / max_position_embeddings as f32)
                     - (scaling_factor - 1.0)))
                 .powi((rotary_dim as f32 / (rotary_dim as f32 - 2.0)) as i32);
             let inv_freqs = get_inv_freqs(rotary_dim, new_base, vb.device(), None)?;
@@ -258,7 +265,7 @@ impl FlashNomicBertModel {
             embeddings,
             encoder,
             pool,
-            max_trained_positions: config.max_trained_positions as u32,
+            max_position_embeddings: max_position_embeddings as u32,
             rotary_cache,
             scaled_rotary_cache,
             device: vb.device().clone(),
@@ -283,7 +290,7 @@ impl FlashNomicBertModel {
         )?;
 
         let (cos, sin) = if self.scaled_rotary_cache.is_some()
-            && batch.max_length > self.max_trained_positions
+            && batch.max_length > self.max_position_embeddings
         {
             let cos = index_select(
                 &self.scaled_rotary_cache.as_ref().unwrap().0,

--- a/backends/candle/src/models/nomic.rs
+++ b/backends/candle/src/models/nomic.rs
@@ -18,8 +18,13 @@ pub struct NomicConfig {
     pub mlp_fc1_bias: bool,
     pub mlp_fc2_bias: bool,
     pub rotary_scaling_factor: Option<f32>,
-    #[serde(default = "default_max_trained_positions")]
-    pub max_trained_positions: usize,
+
+    // NOTE: `max_trained_positions` is specific for NomicBERT when it required custom code, but
+    // since Transformers v5 it's no longer required, and it now defines `max_position_embeddings`
+    // in the `config.json` instead. Not included as an `alias` since both can be present at the
+    // same time, see https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/blob/e9b6763023c676ca8431644204f50c2b100d9aab/config.json#L33-L34
+    pub max_trained_positions: Option<usize>,
+    pub max_position_embeddings: Option<usize>,
 
     pub moe_every_n_layers: Option<usize>,
     pub moe_normalize_expert_weights: Option<bool>,
@@ -37,10 +42,6 @@ pub struct NomicConfig {
     pub vocab_size: usize,
     pub type_vocab_size: usize,
     pub layer_norm_epsilon: f32,
-}
-
-fn default_max_trained_positions() -> usize {
-    2048
 }
 
 impl NomicConfig {
@@ -668,7 +669,7 @@ pub struct NomicBertModel {
     dtype: DType,
 
     rotary_dim: usize,
-    max_trained_positions: u32,
+    max_position_embeddings: u32,
     rotary_cache: (Tensor, Tensor),
     scaled_rotary_cache: Option<(Tensor, Tensor)>,
 
@@ -702,6 +703,14 @@ impl NomicBertModel {
         let embeddings = NomicBertEmbeddings::load(vb.clone(), config)?;
         let encoder = NomicBertEncoder::load(vb.pp("encoder"), config)?;
 
+        let max_position_embeddings = match config.max_position_embeddings {
+            Some(max_position_embeddings) => max_position_embeddings,
+            None => match config.max_trained_positions {
+                Some(max_trained_positions) => max_trained_positions,
+                None => 2048,
+            },
+        };
+
         let rotary_dim = encoder.layers[0].attention.attention_head_size;
         let inv_freqs_tensor =
             get_inv_freqs(rotary_dim, config.rotary_emb_base, vb.device(), None)?;
@@ -709,8 +718,7 @@ impl NomicBertModel {
 
         let scaled_rotary_cache = if let Some(scaling_factor) = config.rotary_scaling_factor {
             let new_base = (config.rotary_emb_base
-                * ((scaling_factor * config.n_positions as f32
-                    / config.max_trained_positions as f32)
+                * ((scaling_factor * config.n_positions as f32 / max_position_embeddings as f32)
                     - (scaling_factor - 1.0)))
                 .powi((rotary_dim as f32 / (rotary_dim as f32 - 2.0)) as i32);
             let inv_freqs_tensor = get_inv_freqs(rotary_dim, new_base, vb.device(), None)?;
@@ -729,7 +737,7 @@ impl NomicBertModel {
             encoder,
             pool,
             rotary_dim,
-            max_trained_positions: config.max_trained_positions as u32,
+            max_position_embeddings: max_position_embeddings as u32,
             rotary_cache,
             scaled_rotary_cache,
             num_attention_heads: config.n_head,
@@ -855,7 +863,7 @@ impl NomicBertModel {
             Tensor::from_vec(input_lengths, (batch_size, 1), &self.device)?.to_dtype(self.dtype)?;
 
         let (cos, sin) = if self.scaled_rotary_cache.is_some()
-            && batch.max_length > self.max_trained_positions
+            && batch.max_length > self.max_position_embeddings
         {
             let cos = self
                 .scaled_rotary_cache

--- a/backends/candle/src/models/nomic.rs
+++ b/backends/candle/src/models/nomic.rs
@@ -703,13 +703,9 @@ impl NomicBertModel {
         let embeddings = NomicBertEmbeddings::load(vb.clone(), config)?;
         let encoder = NomicBertEncoder::load(vb.pp("encoder"), config)?;
 
-        let max_position_embeddings = match config.max_position_embeddings {
-            Some(max_position_embeddings) => max_position_embeddings,
-            None => match config.max_trained_positions {
-                Some(max_trained_positions) => max_trained_positions,
-                None => 2048,
-            },
-        };
+        let max_position_embeddings = config
+            .max_position_embeddings
+            .unwrap_or(config.max_trained_positions.unwrap_or(2048));
 
         let rotary_dim = encoder.layers[0].attention.attention_head_size;
         let inv_freqs_tensor =

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -197,11 +197,19 @@ pub async fn run(
         }
     }
 
+    let max_position_embeddings = match config.max_position_embeddings {
+        Some(max_position_embeddings) => max_position_embeddings,
+        None => match config.max_trained_positions {
+            Some(max_trained_positions) => max_trained_positions,
+            None => anyhow::bail!("At least any of `max_position_embeddings` or `max_trained_positions` (only applies for NomicBERT), in that order of priority, should be defined in `config.json`."),
+        },
+    };
+
     let base_input_length = match st_config {
         Some(config) => config.max_seq_length,
         None => {
             tracing::warn!("Could not find a Sentence Transformers config");
-            config.max_position_embeddings - position_offset
+            max_position_embeddings - position_offset
         }
     };
 
@@ -456,8 +464,12 @@ fn get_backend_model_type(
 pub struct ModelConfig {
     pub architectures: Vec<String>,
     pub model_type: String,
-    #[serde(alias = "n_positions")]
-    pub max_position_embeddings: usize,
+    // NOTE: `max_trained_positions` is specific for NomicBERT when it required custom code, but
+    // since Transformers v5 it's no longer required, and it now defines `max_position_embeddings`
+    // in the `config.json` instead. Not included as an `alias` since both can be present at the
+    // same time, see https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/blob/e9b6763023c676ca8431644204f50c2b100d9aab/config.json#L33-L34
+    pub max_trained_positions: Option<usize>,
+    pub max_position_embeddings: Option<usize>,
     #[serde(default)]
     pub pad_token_id: Option<usize>,
     pub id2label: Option<HashMap<String, String>>,


### PR DESCRIPTION
# What does this PR do?

This PR fixes the handling for `max_position_embeddings` in both `NomicBertConfig` and `FlashNomicBertConfig` so that instead of using `max_trained_positions` as the default value, which was only required when the model was flagged with custom code on the Hugging Face Hub, since now those `config.json` have been updated to be natively supported without custom code as per e.g., https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/commit/e9b6763023c676ca8431644204f50c2b100d9aab.

Additionally, this PR also solves an issue with using `alias` for `n_positions` for the default value of `max_position_embeddings` when it was not provided in the `config.json`, to instead not use `alias` (as when the keys in `config.json` are duplicate it will raise an error) and use `max_trained_positions` as the fallback, assuming that both `max_position_embeddings` and `max_trained_positions` are optional, but at least one needs to be set, in that order of priority.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.