### PR TITLE
Add HTTP rerank endpoint coverage

### DIFF
--- a/router/tests/common.rs
+++ b/router/tests/common.rs
@@ -5,9 +5,11 @@ use text_embeddings_backend::DType;
 use text_embeddings_router::run;
 use tokio::time::Instant;
 
+#[allow(dead_code)]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Score(f32);
 
+#[allow(dead_code)]
 impl Score {
     fn is_close(&self, other: &Self, abs_tol: f32) -> bool {
         is_close::default()
@@ -43,7 +45,18 @@ async fn check_health(port: u16, timeout: Duration) -> Result<()> {
     }
 }
 
+#[allow(dead_code)]
 pub async fn start_server(model_id: String, revision: Option<String>, dtype: DType) -> Result<()> {
+    start_server_with_ports(model_id, revision, dtype, 8090, 9000).await
+}
+
+pub async fn start_server_with_ports(
+    model_id: String,
+    revision: Option<String>,
+    dtype: DType,
+    port: u16,
+    prometheus_port: u16,
+) -> Result<()> {
     let server_task = tokio::spawn({
         run(
             model_id.clone(),
@@ -62,21 +75,21 @@ pub async fn start_server(model_id: String, revision: Option<String>, dtype: DTy
             None,
             None,
             None,
-            8090,
+            port,
             None,
             None,
             2_000_000,
             None,
             None,
             "text-embeddings-inference.server".to_owned(),
-            9000,
+            prometheus_port,
             None,
         )
     });
 
     tokio::select! {
         err = server_task => err?,
-        _ = check_health(8090, Duration::from_secs(60)) => Ok(())
+        _ = check_health(port, Duration::from_secs(60)) => Ok(())
     }?;
     Ok(())
 }

--- a/router/tests/snapshots/test_http_rerank__ranks.snap
+++ b/router/tests/snapshots/test_http_rerank__ranks.snap
@@ -1,0 +1,8 @@
+---
+source: router/tests/test_http_rerank.rs
+expression: snapshot_ranks
+---
+- index: 0
+  text: Deep learning is a subset of machine learning that uses neural networks.
+- index: 1
+  text: A kitten plays with yarn in the garden.

--- a/router/tests/test_http_rerank.rs
+++ b/router/tests/test_http_rerank.rs
@@ -1,44 +1,78 @@
-// mod common;
-//
-// use crate::common::{start_server, Score};
-// use anyhow::Result;
-// use insta::internals::YamlMatcher;
-// use serde::{Deserialize, Serialize};
-// use serde_json::json;
-// use text_embeddings_backend::DType;
-//
-// #[derive(Serialize, Deserialize, Debug, PartialEq)]
-// pub struct SnapshotRank {
-//     index: usize,
-//     score: Score,
-//     text: String,
-// }
-//
-// #[tokio::test]
-// #[cfg(feature = "http")]
-// async fn test_rerank() -> Result<()> {
-//     start_server("BAAI/bge-reranker-base".to_string(), None, DType::Float32).await?;
-//
-//     let request = json!({
-//         "query": "test",
-//         "texts": vec!["test", "other", "test"],
-//         "return_text": true
-//     });
-//
-//     let client = reqwest::Client::new();
-//     let res = client
-//         .post("http://0.0.0.0:8090/rerank")
-//         .json(&request)
-//         .send()
-//         .await?;
-//
-//     let ranks = res.json::<Vec<SnapshotRank>>().await?;
-//     let matcher = YamlMatcher::<Vec<SnapshotRank>>::new();
-//     insta::assert_yaml_snapshot!("ranks", ranks, &matcher);
-//
-//     assert_eq!(ranks[0].index, 2);
-//     assert_eq!(ranks[1].index, 0);
-//     assert_eq!(ranks[0].score, ranks[1].score);
-//
-//     Ok(())
-// }
+mod common;
+
+use crate::common::start_server_with_ports;
+use anyhow::Result;
+use insta::internals::YamlMatcher;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use text_embeddings_backend::DType;
+
+#[derive(Deserialize, Debug)]
+pub struct Rank {
+    index: usize,
+    score: f32,
+    text: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SnapshotRank {
+    index: usize,
+    text: String,
+}
+
+#[tokio::test]
+#[serial_test::serial]
+#[cfg(feature = "http")]
+async fn test_rerank() -> Result<()> {
+    let port = 8091;
+    start_server_with_ports(
+        "cross-encoder/ms-marco-MiniLM-L2-v2".to_string(),
+        None,
+        DType::Float32,
+        port,
+        9001,
+    )
+    .await?;
+
+    let request = json!({
+        "query": "What is deep learning?",
+        "texts": [
+            "Deep learning is a subset of machine learning that uses neural networks.",
+            "A kitten plays with yarn in the garden."
+        ],
+        "return_text": true
+    });
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!("http://0.0.0.0:{port}/rerank"))
+        .json(&request)
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let ranks = res.json::<Vec<Rank>>().await?;
+
+    assert_eq!(ranks.len(), 2);
+    assert_eq!(ranks[0].index, 0);
+    assert_eq!(
+        ranks[0].text,
+        "Deep learning is a subset of machine learning that uses neural networks."
+    );
+    assert!(ranks[0].score.is_finite());
+    assert!(ranks[1].score.is_finite());
+    assert!(ranks[0].score > ranks[1].score);
+
+    let snapshot_ranks = ranks
+        .into_iter()
+        .map(|rank| SnapshotRank {
+            index: rank.index,
+            text: rank.text,
+        })
+        .collect::<Vec<_>>();
+    let matcher = YamlMatcher::<Vec<SnapshotRank>>::new();
+    insta::assert_yaml_snapshot!("ranks", snapshot_ranks, &matcher);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add active HTTP `/rerank` integration coverage using the small public `cross-encoder/ms-marco-MiniLM-L2-v2` reranker.
- Use dedicated HTTP/prometheus ports for this test to avoid collisions with the existing HTTP embedding test.
- Snapshot only stable response shape (`index` and `text`) while asserting ranking and finite scores directly, avoiding brittle raw floating-point score snapshots.

## Notes

The selected reranker has a relatively small `model.safetensors` artifact (~62 MB), keeping the test closer in footprint to the existing HTTP embedding coverage than larger reranker models.

## Test plan

- `rustfmt --edition 2021 router/tests/common.rs router/tests/test_http_rerank.rs`
- `cargo test -p text-embeddings-router test_rerank -- --nocapture`
- `cargo test -p text-embeddings-router --tests -- --nocapture`
- `cargo test --profile=release-debug -p text-embeddings-router test_rerank -- --nocapture`
- `cargo test --profile=release-debug -p text-embeddings-router --tests -- --nocapture`
- `cargo test --profile=release-debug`
