### PR TITLE
fix(candle): always apply attention masks for Qwen3 and Gemma3 batches

### DIFF
--- a/backends/candle/Cargo.toml
+++ b/backends/candle/Cargo.toml
@@ -34,6 +34,7 @@ hf-hub = { workspace = true, features = ["ureq"] }
 anyhow = { workspace = true }
 tokenizers = { workspace = true }
 serial_test = { workspace = true }
+candle = { workspace = true }
 
 [build-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/backends/candle/src/models/gemma3.rs
+++ b/backends/candle/src/models/gemma3.rs
@@ -785,6 +785,17 @@ impl Gemma3Model {
             (input_ids, position_ids, input_lengths, Some(attention_bias))
         };
 
+        let attention_bias = match attention_bias {
+            Some(attention_bias) => Some(attention_bias),
+            // Force each attention layer to add its causal or sliding-window mask,
+            // even when an equal-length batch needs no padding bias.
+            None => Some(Tensor::zeros(
+                (batch_size, self.num_attention_heads, max_length, max_length),
+                self.dtype,
+                &self.device,
+            )?),
+        };
+
         let mut hidden_states = self.embed_tokens.forward(&input_ids)?;
 
         let cos = self

--- a/backends/candle/src/models/qwen3.rs
+++ b/backends/candle/src/models/qwen3.rs
@@ -601,10 +601,23 @@ impl Qwen3Model {
 
         let attention_bias = if self.use_bidirectional_attention {
             attention_bias
-        } else if let Some(attn_bias) = attention_bias {
-            Some(self.get_causal_attention_bias(attn_bias)?)
         } else {
-            None
+            // Causal models MUST always apply the causal mask, even when the batch
+            // needs no padding (all sequences equal length => `attention_bias` is
+            // `None`). Previously the causal mask was only applied when padding was
+            // present, so an equal-length multi-sequence batch silently ran
+            // *bidirectional* attention and produced embeddings inconsistent with
+            // single-sequence (always-causal) inference. Build a zero bias to mask
+            // onto when none exists, mirroring the `batch_size == 1` path above.
+            let attn_bias = match attention_bias {
+                Some(attn_bias) => attn_bias,
+                None => Tensor::zeros(
+                    (batch_size, self.num_attention_heads, max_length, max_length),
+                    self.dtype,
+                    &self.device,
+                )?,
+            };
+            Some(self.get_causal_attention_bias(attn_bias)?)
         };
 
         let mut hidden_states = self.embeddings.forward(&input_ids)?;

--- a/backends/candle/tests/test_gemma3_equal_length_batch.rs
+++ b/backends/candle/tests/test_gemma3_equal_length_batch.rs
@@ -1,0 +1,189 @@
+//! Regression test for the Gemma3 equal-length-batch attention-mask bug.
+//!
+//! Gemma3 attention layers add their causal or sliding-window mask only when the model
+//! passes an attention bias tensor. Before the fix, an equal-length multi-sequence
+//! batch needed no padding, so `Gemma3Model::forward` passed `None` and every layer
+//! skipped its attention mask. This test uses tiny random weights and verifies that
+//! equal-length batched inference matches single-sequence inference.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use candle::{Device, Tensor};
+use text_embeddings_backend_candle::CandleBackend;
+use text_embeddings_backend_core::{Backend, Batch, Embedding, Embeddings, ModelType, Pool};
+
+const H: usize = 64;
+const HEADS: usize = 4;
+const HEAD_DIM: usize = 16;
+const KV: usize = 2;
+const INTER: usize = 128;
+const LAYERS: usize = 16;
+const VOCAB: usize = 256;
+
+fn w(rows: usize, cols: usize, dev: &Device) -> Result<Tensor> {
+    Ok(Tensor::randn(0f32, 0.1f32, (rows, cols), dev)?)
+}
+
+fn norm(n: usize, dev: &Device) -> Result<Tensor> {
+    Ok(Tensor::randn(0f32, 0.05f32, (n,), dev)?)
+}
+
+fn write_random_gemma3(dir: &std::path::Path) -> Result<()> {
+    let dev = Device::Cpu;
+    let mut t: HashMap<String, Tensor> = HashMap::new();
+    t.insert(
+        "embed_tokens.weight".to_string(),
+        Tensor::randn(0f32, 1f32, (VOCAB, H), &dev)?,
+    );
+    for l in 0..LAYERS {
+        let p = format!("layers.{l}.");
+        t.insert(
+            format!("{p}self_attn.q_proj.weight"),
+            w(HEADS * HEAD_DIM, H, &dev)?,
+        );
+        t.insert(
+            format!("{p}self_attn.k_proj.weight"),
+            w(KV * HEAD_DIM, H, &dev)?,
+        );
+        t.insert(
+            format!("{p}self_attn.v_proj.weight"),
+            w(KV * HEAD_DIM, H, &dev)?,
+        );
+        t.insert(
+            format!("{p}self_attn.o_proj.weight"),
+            w(H, HEADS * HEAD_DIM, &dev)?,
+        );
+        t.insert(format!("{p}self_attn.q_norm.weight"), norm(HEAD_DIM, &dev)?);
+        t.insert(format!("{p}self_attn.k_norm.weight"), norm(HEAD_DIM, &dev)?);
+        t.insert(format!("{p}mlp.gate_proj.weight"), w(INTER, H, &dev)?);
+        t.insert(format!("{p}mlp.up_proj.weight"), w(INTER, H, &dev)?);
+        t.insert(format!("{p}mlp.down_proj.weight"), w(H, INTER, &dev)?);
+        t.insert(format!("{p}input_layernorm.weight"), norm(H, &dev)?);
+        t.insert(
+            format!("{p}post_attention_layernorm.weight"),
+            norm(H, &dev)?,
+        );
+        t.insert(
+            format!("{p}pre_feedforward_layernorm.weight"),
+            norm(H, &dev)?,
+        );
+        t.insert(
+            format!("{p}post_feedforward_layernorm.weight"),
+            norm(H, &dev)?,
+        );
+    }
+    t.insert("norm.weight".to_string(), norm(H, &dev)?);
+    candle::safetensors::save(&t, dir.join("model.safetensors"))?;
+
+    let config = format!(
+        r#"{{
+  "model_type": "gemma3_text",
+  "attention_bias": false,
+  "pad_token_id": 0,
+  "vocab_size": {VOCAB},
+  "head_dim": {HEAD_DIM},
+  "hidden_activation": "silu",
+  "hidden_size": {H},
+  "intermediate_size": {INTER},
+  "max_position_embeddings": 512,
+  "num_hidden_layers": {LAYERS},
+  "num_attention_heads": {HEADS},
+  "num_key_value_heads": {KV},
+  "query_pre_attn_scalar": {HEAD_DIM},
+  "rms_norm_eps": 1e-6,
+  "rope_local_base_freq": 10000.0,
+  "rope_theta": 1000000.0,
+  "sliding_window": 4,
+  "_sliding_window_pattern": 2,
+  "use_bidirectional_attention": false
+}}"#
+    );
+    std::fs::write(dir.join("config.json"), config)?;
+    Ok(())
+}
+
+fn pooled(embeddings: &Embeddings, i: usize) -> Vec<f32> {
+    match embeddings.get(&i).expect("missing embedding") {
+        Embedding::Pooled(e) => e.clone(),
+        Embedding::All(_) => panic!("expected pooled embedding"),
+    }
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot / (na * nb)
+}
+
+fn single(ids: &[u32]) -> Batch {
+    Batch {
+        input_ids: ids.to_vec(),
+        token_type_ids: vec![0; ids.len()],
+        position_ids: (0..ids.len() as u32).collect(),
+        cumulative_seq_lengths: vec![0, ids.len() as u32],
+        max_length: ids.len() as u32,
+        pooled_indices: vec![0],
+        raw_indices: vec![],
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn test_gemma3_equal_length_batch_matches_single() -> Result<()> {
+    let dir = std::env::temp_dir().join(format!("tei_gemma3_rand_{}", std::process::id()));
+    std::fs::create_dir_all(&dir)?;
+    let res = run(&dir);
+    std::fs::remove_dir_all(&dir).ok();
+    res
+}
+
+fn run(dir: &std::path::Path) -> Result<()> {
+    write_random_gemma3(dir)?;
+
+    let backend = CandleBackend::new(
+        dir,
+        "float32".to_string(),
+        ModelType::Embedding(Pool::Mean),
+        None,
+    )?;
+
+    let a: Vec<u32> = vec![5, 9, 13, 17, 21, 25, 29, 33];
+    let b: Vec<u32> = vec![6, 10, 14, 18, 22, 26, 30, 34];
+    assert_eq!(a.len(), b.len(), "sequences must be equal length");
+
+    let single_a = pooled(&backend.embed(single(&a))?, 0);
+    let single_b = pooled(&backend.embed(single(&b))?, 0);
+
+    let pair = Batch {
+        input_ids: [a.clone(), b.clone()].concat(),
+        token_type_ids: vec![0; a.len() + b.len()],
+        position_ids: [
+            (0..a.len() as u32).collect::<Vec<_>>(),
+            (0..b.len() as u32).collect::<Vec<_>>(),
+        ]
+        .concat(),
+        cumulative_seq_lengths: vec![0, a.len() as u32, (a.len() + b.len()) as u32],
+        max_length: a.len() as u32,
+        pooled_indices: vec![0, 1],
+        raw_indices: vec![],
+    };
+    let pair_emb = backend.embed(pair)?;
+    let pair_a = pooled(&pair_emb, 0);
+    let pair_b = pooled(&pair_emb, 1);
+
+    let cos_a = cosine(&pair_a, &single_a);
+    let cos_b = cosine(&pair_b, &single_b);
+    eprintln!("Gemma3 equal-length batch vs single: cos_a={cos_a:.6}, cos_b={cos_b:.6}");
+
+    assert!(
+        cos_a > 0.99,
+        "equal-length Gemma3 batch[0] diverged from single inference (cos={cos_a}); attention mask skipped for no-padding batch?"
+    );
+    assert!(
+        cos_b > 0.99,
+        "equal-length Gemma3 batch[1] diverged from single inference (cos={cos_b}); attention mask skipped for no-padding batch?"
+    );
+    Ok(())
+}

--- a/backends/candle/tests/test_qwen3_equal_length_batch.rs
+++ b/backends/candle/tests/test_qwen3_equal_length_batch.rs
@@ -1,0 +1,187 @@
+//! Regression test for the equal-length-batch causal-mask bug.
+//!
+//! A causal model must apply the causal attention mask for EVERY multi-sequence batch,
+//! even when all sequences are the same length (so the batch needs no padding). Before
+//! the fix, `Qwen3Model::forward` only built the causal mask when padding was present;
+//! an equal-length batch left `attention_bias = None` and silently ran *bidirectional*
+//! attention, so the same text embedded differently in a batch than on its own.
+//!
+//! This test uses tiny RANDOM weights (no model download). The batch-vs-single
+//! divergence is weight-independent and compounds with depth, so a handful of layers
+//! makes it unmistakable: on the buggy code the equal-length batch diverges from single
+//! inference (cos well below 1.0); with the fix it matches (cos ~1.0).
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use candle::{Device, Tensor};
+use text_embeddings_backend_candle::CandleBackend;
+use text_embeddings_backend_core::{Backend, Batch, Embedding, Embeddings, ModelType, Pool};
+
+const H: usize = 64;
+const HEADS: usize = 4;
+const HEAD_DIM: usize = 16;
+const KV: usize = 2;
+const INTER: usize = 128;
+const LAYERS: usize = 24; // deep enough that the bidirectional leak is unmistakable
+const VOCAB: usize = 256;
+
+fn w(rows: usize, cols: usize, dev: &Device) -> Result<Tensor> {
+    Ok(Tensor::randn(0f32, 0.1f32, (rows, cols), dev)?)
+}
+fn norm(n: usize, dev: &Device) -> Result<Tensor> {
+    Ok((Tensor::randn(0f32, 0.05f32, (n,), dev)? + 1.0)?)
+}
+
+/// Write a small, architecture-faithful, random-weight Qwen3 model to `dir`.
+fn write_random_qwen3(dir: &std::path::Path) -> Result<()> {
+    let dev = Device::Cpu;
+    let mut t: HashMap<String, Tensor> = HashMap::new();
+    t.insert(
+        "model.embed_tokens.weight".to_string(),
+        Tensor::randn(0f32, 1f32, (VOCAB, H), &dev)?,
+    );
+    for l in 0..LAYERS {
+        let p = format!("model.layers.{l}.");
+        t.insert(
+            format!("{p}self_attn.q_proj.weight"),
+            w(HEADS * HEAD_DIM, H, &dev)?,
+        );
+        t.insert(
+            format!("{p}self_attn.k_proj.weight"),
+            w(KV * HEAD_DIM, H, &dev)?,
+        );
+        t.insert(
+            format!("{p}self_attn.v_proj.weight"),
+            w(KV * HEAD_DIM, H, &dev)?,
+        );
+        t.insert(
+            format!("{p}self_attn.o_proj.weight"),
+            w(H, HEADS * HEAD_DIM, &dev)?,
+        );
+        t.insert(format!("{p}self_attn.q_norm.weight"), norm(HEAD_DIM, &dev)?);
+        t.insert(format!("{p}self_attn.k_norm.weight"), norm(HEAD_DIM, &dev)?);
+        t.insert(format!("{p}mlp.gate_proj.weight"), w(INTER, H, &dev)?);
+        t.insert(format!("{p}mlp.up_proj.weight"), w(INTER, H, &dev)?);
+        t.insert(format!("{p}mlp.down_proj.weight"), w(H, INTER, &dev)?);
+        t.insert(format!("{p}input_layernorm.weight"), norm(H, &dev)?);
+        t.insert(
+            format!("{p}post_attention_layernorm.weight"),
+            norm(H, &dev)?,
+        );
+    }
+    t.insert("model.norm.weight".to_string(), norm(H, &dev)?);
+    candle::safetensors::save(&t, dir.join("model.safetensors"))?;
+
+    let config = format!(
+        r#"{{
+  "model_type": "qwen3",
+  "attention_bias": false,
+  "vocab_size": {VOCAB},
+  "head_dim": {HEAD_DIM},
+  "hidden_size": {H},
+  "intermediate_size": {INTER},
+  "num_hidden_layers": {LAYERS},
+  "num_attention_heads": {HEADS},
+  "num_key_value_heads": {KV},
+  "hidden_act": "silu",
+  "max_position_embeddings": 512,
+  "rms_norm_eps": 1e-6,
+  "rope_theta": 1000000.0,
+  "use_sliding_window": false,
+  "eos_token_id": 0
+}}"#
+    );
+    std::fs::write(dir.join("config.json"), config)?;
+    Ok(())
+}
+
+fn pooled(embeddings: &Embeddings, i: usize) -> Vec<f32> {
+    match embeddings.get(&i).expect("missing embedding") {
+        Embedding::Pooled(e) => e.clone(),
+        Embedding::All(_) => panic!("expected pooled embedding"),
+    }
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let na = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let nb = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot / (na * nb)
+}
+
+fn single(ids: &[u32]) -> Batch {
+    Batch {
+        input_ids: ids.to_vec(),
+        token_type_ids: vec![0; ids.len()],
+        position_ids: (0..ids.len() as u32).collect(),
+        cumulative_seq_lengths: vec![0, ids.len() as u32],
+        max_length: ids.len() as u32,
+        pooled_indices: vec![0],
+        raw_indices: vec![],
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn test_qwen3_equal_length_batch_matches_single() -> Result<()> {
+    let dir = std::env::temp_dir().join(format!("tei_qwen3_rand_{}", std::process::id()));
+    std::fs::create_dir_all(&dir)?;
+    let res = run(&dir);
+    std::fs::remove_dir_all(&dir).ok();
+    res
+}
+
+fn run(dir: &std::path::Path) -> Result<()> {
+    write_random_qwen3(dir)?;
+
+    let backend = CandleBackend::new(
+        dir,
+        "float32".to_string(),
+        ModelType::Embedding(Pool::LastToken),
+        None,
+    )?;
+
+    // Two DIFFERENT sequences of the SAME length. Batched together they need no
+    // padding, which is exactly the case that used to skip the causal mask.
+    let a: Vec<u32> = vec![5, 9, 13, 17, 21, 25, 29, 33];
+    let b: Vec<u32> = vec![6, 10, 14, 18, 22, 26, 30, 34];
+    assert_eq!(a.len(), b.len(), "sequences must be equal length");
+
+    let single_a = pooled(&backend.embed(single(&a))?, 0);
+    let single_b = pooled(&backend.embed(single(&b))?, 0);
+
+    let pair = Batch {
+        input_ids: [a.clone(), b.clone()].concat(),
+        token_type_ids: vec![0; a.len() + b.len()],
+        position_ids: [
+            (0..a.len() as u32).collect::<Vec<_>>(),
+            (0..b.len() as u32).collect::<Vec<_>>(),
+        ]
+        .concat(),
+        cumulative_seq_lengths: vec![0, a.len() as u32, (a.len() + b.len()) as u32],
+        max_length: a.len() as u32,
+        pooled_indices: vec![0, 1],
+        raw_indices: vec![],
+    };
+    let pair_emb = backend.embed(pair)?;
+    let pair_a = pooled(&pair_emb, 0);
+    let pair_b = pooled(&pair_emb, 1);
+
+    let cos_a = cosine(&pair_a, &single_a);
+    let cos_b = cosine(&pair_b, &single_b);
+    eprintln!("equal-length batch vs single: cos_a={cos_a:.6}, cos_b={cos_b:.6}");
+
+    // A causal model must give the same embedding for a text whether it is embedded
+    // alone or in an equal-length batch. Without the causal mask the equal-length
+    // batch runs bidirectional attention and these cosines collapse well below 1.0.
+    assert!(
+        cos_a > 0.99,
+        "equal-length batch[0] diverged from single inference (cos={cos_a}); causal mask skipped for no-padding batch?"
+    );
+    assert!(
+        cos_b > 0.99,
+        "equal-length batch[1] diverged from single inference (cos={cos_b}); causal mask skipped for no-padding batch?"
+    );
+    Ok(())
+}


### PR DESCRIPTION
# What does this PR do?

Fixes #882.

Fixes equal-length batched inference for Qwen3 and Gemma3 on the candle backend.

- Qwen3 now always applies the causal mask for non-bidirectional models, synthesizing a zero base bias when the batch needs no padding.
- Gemma3 now passes a zero base bias when the batch needs no padding, so each attention layer still adds its causal or sliding-window mask.
- Adds no-download synthetic-weight regression tests for both models.

## Why

The previous code only created an attention bias for multi-sequence batches when padding was required. Equal-length batches need no padding, so `attention_bias` stayed `None`.

For Qwen3, that meant the causal mask was skipped.

For Gemma3, the per-layer causal/sliding-window mask is created only when an attention bias tensor is present, so equal-length batches skipped those masks as well.

Single-sequence inference already creates a zero bias and therefore remains correctly masked. As a result, the same text could embed differently alone vs in an equal-length backend batch.

No new runtime dependencies are required. The only manifest change adds `candle` as a dev-dependency for synthetic safetensors generation in the new tests.

## Validation

Using the repository-pinned Rust toolchain from `rust-toolchain.toml`:

```text
rustc 1.92.0 (ded5c06cf 2025-12-08)
cargo 1.92.0 (344c4567c 2025-10-21)
```

Positive synthetic-weight tests on the fixed branch, CPU, no model download:

```bash
cargo test -p text-embeddings-backend-candle --test test_qwen3_equal_length_batch --test test_gemma3_equal_length_batch
```

Result:

```text
test test_gemma3_equal_length_batch_matches_single ... ok
test test_qwen3_equal_length_batch_matches_single ... ok
```

Negative evidence, restoring only the old Qwen3 mask gate:

```text
equal-length batch vs single: cos_a=0.613198, cos_b=0.617658
equal-length batch[0] diverged from single inference (cos=0.61319774); causal mask skipped for no-padding batch?
```

Negative evidence, restoring only the old Gemma3 no-bias behavior:

```text
Gemma3 equal-length batch vs single: cos_a=0.924376, cos_b=0.900559
equal-length Gemma3 batch[0] diverged from single inference (cos=0.92437583); attention mask skipped for no-padding batch?
```

Formatting:

```bash
cargo fmt -p text-embeddings-backend-candle -- --check
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? See #882.
- [x] Did you make sure to update the documentation with your changes? Not applicable: this is a backend correctness fix with no user-facing API or documentation change.
- [x] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots? Added synthetic-weight Qwen3 and Gemma3 regression tests; no `insta` snapshots are needed.

## Notes

The original Qwen3 issue was also reproduced with real `Qwen/Qwen3-Embedding-0.6B` on CPU in fp32 and fp16, and without MKL. These tests keep the upstream regression coverage small and deterministic enough for CI by using tiny random synthetic weights.
