### PR TITLE
feat: allow controlling startup warmup tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,13 @@ Options:
           [env: PROMETHEUS_PORT=]
           [default: 9000]
 
+      --warmup-tokens <WARMUP_TOKENS>
+          Control the number of tokens used for model warmup (a synthetic inference pass that can pre-allocate memory and trigger kernel compilation).
+
+          Defaults to `min(max_input_length, max_batch_tokens)` on CPU and `max_batch_tokens` on GPU. Set to `0` to skip the explicit warmup pass for fast cold-start scenarios like CPU spot instances. Positive values are ignored by HPU and ROCm backends, which use backend-specific warmup.
+
+          [env: WARMUP_TOKENS=]
+
       --cors-allow-origin <CORS_ALLOW_ORIGIN>
           Unused for gRPC servers
 

--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -75,6 +75,23 @@ fn is_rocm() -> bool {
     }
 }
 
+fn effective_warmup_tokens(
+    max_input_length: usize,
+    max_batch_tokens: usize,
+    padded_model: bool,
+    warmup_tokens: Option<usize>,
+) -> Result<Option<usize>, BackendError> {
+    match warmup_tokens {
+        Some(0) => Ok(None),
+        Some(tokens) if tokens > max_batch_tokens => Err(BackendError::Start(format!(
+            "warmup_tokens ({tokens}) exceeds max_batch_tokens ({max_batch_tokens}); set `--warmup-tokens` to at most `--max-batch-tokens` or increase `--max-batch-tokens`"
+        ))),
+        Some(tokens) => Ok(Some(tokens)),
+        None if padded_model => Ok(Some(max_input_length.min(max_batch_tokens))),
+        None => Ok(Some(max_batch_tokens)),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Backend {
     /// Channel to communicate with the background thread
@@ -305,36 +322,55 @@ impl Backend {
         max_batch_tokens: usize,
         max_batch_requests: Option<usize>,
         padded_model: bool,
+        warmup_tokens: Option<usize>,
     ) -> Result<(), BackendError> {
+        if warmup_tokens == Some(0) {
+            tracing::warn!("Explicit warmup skipped via --warmup-tokens=0");
+            return Ok(());
+        }
+
         if is_hpu() {
+            if warmup_tokens.is_some() {
+                tracing::warn!("--warmup-tokens is not supported on HPU backends; ignoring");
+            }
             return self
                 .warmup_hpu(max_input_length, max_batch_tokens, max_batch_requests)
                 .await;
         }
 
         if is_rocm() {
+            if warmup_tokens.is_some() {
+                tracing::warn!("--warmup-tokens is not supported on ROCM backends; ignoring");
+            }
             return self
                 .warmup_rocm(max_input_length, max_batch_tokens, max_batch_requests)
                 .await;
         }
 
-        // In padded_model (CPU), use minimal warmup size (max_input_length tokens) for fast startup
-        // Non-padded (GPU), use full max_batch_tokens to exercise production batching limits
-        let warmup_tokens = if padded_model {
-            max_input_length.min(max_batch_tokens)
-        } else {
-            max_batch_tokens
+        // In padded_model (CPU), use minimal warmup size (max_input_length tokens) for fast startup.
+        // Non-padded (GPU), use full max_batch_tokens to exercise production batching limits.
+        let effective_tokens = match effective_warmup_tokens(
+            max_input_length,
+            max_batch_tokens,
+            padded_model,
+            warmup_tokens,
+        )? {
+            Some(tokens) => tokens,
+            None => {
+                tracing::warn!("Explicit warmup skipped via --warmup-tokens=0");
+                return Ok(());
+            }
         };
 
-        let mut input_ids = Vec::with_capacity(warmup_tokens);
-        let mut token_type_ids = Vec::with_capacity(warmup_tokens);
-        let mut position_ids = Vec::with_capacity(warmup_tokens);
+        let mut input_ids = Vec::with_capacity(effective_tokens);
+        let mut token_type_ids = Vec::with_capacity(effective_tokens);
+        let mut position_ids = Vec::with_capacity(effective_tokens);
 
         let mut cumulative_seq_lengths = vec![0];
         let mut pooled_indices = Vec::new();
 
         let mut i = 0_u32;
-        let mut remaining = warmup_tokens;
+        let mut remaining = effective_tokens;
         let mut cumulative_length = 0;
         let mut max_length = 0;
 
@@ -359,6 +395,12 @@ impl Backend {
             }
         }
 
+        tracing::info!(
+            "Warmup with {} tokens across {} sequences (requested {})",
+            input_ids.len(),
+            i,
+            effective_tokens
+        );
         let batch = Batch {
             input_ids,
             token_type_ids,
@@ -436,6 +478,65 @@ impl Backend {
         receiver.await.expect(
             "Backend blocking task dropped the sender without send a response. This is a bug.",
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::effective_warmup_tokens;
+
+    #[test]
+    fn default_padded_warmup_uses_model_or_batch_limit() {
+        assert_eq!(
+            effective_warmup_tokens(32_768, 16_384, true, None).unwrap(),
+            Some(16_384)
+        );
+        assert_eq!(
+            effective_warmup_tokens(512, 16_384, true, None).unwrap(),
+            Some(512)
+        );
+    }
+
+    #[test]
+    fn default_non_padded_warmup_uses_batch_tokens() {
+        assert_eq!(
+            effective_warmup_tokens(512, 16_384, false, None).unwrap(),
+            Some(16_384)
+        );
+    }
+
+    #[test]
+    fn explicit_warmup_tokens_override_default() {
+        assert_eq!(
+            effective_warmup_tokens(32_768, 16_384, true, Some(64)).unwrap(),
+            Some(64)
+        );
+        assert_eq!(
+            effective_warmup_tokens(512, 16_384, false, Some(64)).unwrap(),
+            Some(64)
+        );
+    }
+
+    #[test]
+    fn zero_warmup_tokens_skips_warmup() {
+        assert_eq!(
+            effective_warmup_tokens(32_768, 16_384, true, Some(0)).unwrap(),
+            None
+        );
+        assert_eq!(
+            effective_warmup_tokens(512, 16_384, false, Some(0)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn explicit_warmup_tokens_cannot_exceed_batch_limit() {
+        let err = effective_warmup_tokens(32_768, 16_384, true, Some(16_385))
+            .expect_err("oversized warmup should fail");
+        assert!(
+            err.to_string().contains("exceeds max_batch_tokens"),
+            "unexpected error: {err}"
+        );
     }
 }
 

--- a/docs/source/en/cli_arguments.md
+++ b/docs/source/en/cli_arguments.md
@@ -203,6 +203,13 @@ Options:
           [env: PROMETHEUS_PORT=]
           [default: 9000]
 
+      --warmup-tokens <WARMUP_TOKENS>
+          Control the number of tokens used for model warmup (a synthetic inference pass that can pre-allocate memory and trigger kernel compilation).
+
+          Defaults to `min(max_input_length, max_batch_tokens)` on CPU and `max_batch_tokens` on GPU. Set to `0` to skip the explicit warmup pass for fast cold-start scenarios like CPU spot instances. Positive values are ignored by HPU and ROCm backends, which use backend-specific warmup.
+
+          [env: WARMUP_TOKENS=]
+
       --cors-allow-origin <CORS_ALLOW_ORIGIN>
           Unused for gRPC servers
 

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -66,6 +66,7 @@ pub async fn run(
     otlp_endpoint: Option<String>,
     otlp_service_name: String,
     prometheus_port: u16,
+    warmup_tokens: Option<usize>,
     cors_allow_origin: Option<Vec<String>>,
 ) -> Result<()> {
     let model_id_path = Path::new(&model_id);
@@ -293,6 +294,7 @@ pub async fn run(
             max_batch_tokens,
             max_batch_requests,
             backend.padded_model,
+            warmup_tokens,
         )
         .await
         .context("Model backend is not healthy")?;

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -195,6 +195,16 @@ struct Args {
     #[clap(default_value = "9000", long, env)]
     prometheus_port: u16,
 
+    /// Control the number of tokens used for model warmup (a synthetic inference pass
+    /// that can pre-allocate memory and trigger kernel compilation).
+    ///
+    /// Defaults to `min(max_input_length, max_batch_tokens)` on CPU and
+    /// `max_batch_tokens` on GPU. Set to `0` to skip the explicit warmup pass
+    /// for fast cold-start scenarios like CPU spot instances. Positive values
+    /// are ignored by HPU and ROCm backends, which use backend-specific warmup.
+    #[clap(long, env)]
+    warmup_tokens: Option<usize>,
+
     /// Unused for gRPC servers
     #[clap(long, env)]
     cors_allow_origin: Option<Vec<String>>,
@@ -265,6 +275,7 @@ async fn main() -> Result<()> {
         args.otlp_endpoint,
         args.otlp_service_name,
         args.prometheus_port,
+        args.warmup_tokens,
         args.cors_allow_origin,
     )
     .await?;


### PR DESCRIPTION
## What does this PR do?

Adds a `--warmup-tokens` / `WARMUP_TOKENS` option to control the explicit startup warmup pass.

- Default behavior is unchanged:
  - padded backends use `min(max_input_length, max_batch_tokens)`
  - non-padded backends use `max_batch_tokens`
- `--warmup-tokens 0` skips the explicit warmup pass.
- `--warmup-tokens N` runs a smaller synthetic warmup with `N` tokens.
- Positive values above `--max-batch-tokens` are rejected to avoid startup-only shapes larger than production batching limits.
- HPU and ROCm keep their existing backend-specific bucket warmup for positive values; `0` still skips before that warmup is entered.

This addresses #819, where CPU/ORT Qwen3 ONNX startup was dominated by the warmup pass even after lowering `--max-batch-tokens`.

## Why

Warmup is valuable on GPU because it exercises production batch sizes and can trigger kernel compilation / memory allocation. On CPU spot deployments, especially ORT/ONNX, the same synthetic forward pass can dominate cold start time.

This lets users choose a smaller smoke-test warmup or skip the explicit warmup pass entirely without also lowering `--max-batch-tokens` and changing serving limits.

## Validation

Static/local checks:

```bash
cargo test -p text-embeddings-backend --no-default-features --features ort,clap
cargo test -p text-embeddings-backend --no-default-features --features candle,clap
cargo check -p text-embeddings-router --no-default-features --features ort,http
cargo check -p text-embeddings-router --no-default-features --features candle,http
cargo run -p text-embeddings-router --no-default-features --features ort,http -- --help
git diff --check
```

Runtime timing on macOS/arm64 CPU, release-built ORT/http router, using the model from #819:

```text
Svenni551/Qwen3-Embedding-0.6B-ONNX-INT8
```

Note: current TEI could not start directly from that repo config because the config contains GPT-style alias fields (`n_embd`, `n_layer`, `n_head`) that parse as duplicate aliases for existing Qwen3 fields. I used a temporary local copy with only those alias keys removed; the ONNX weights and tokenizer were unchanged.

Measured process start until `GET /health` succeeded:

| Setup | Default warmup | `--warmup-tokens 0` | `--warmup-tokens 64` |
|---|---:|---:|---:|
| `--max-batch-tokens 1024` | `3.163s` | `1.049s` | `1.590s` |
| default `16384` | still warming after ~4 min, stopped manually | `1.594s` | `1.590s` |

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? See #819.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots? Added unit tests for warmup token selection and validation; no snapshots needed.
