### PR TITLE
feat(qwen3): support reranker on candle backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Below are some examples of the currently supported models:
 | Re-Ranking         | XLM-RoBERTa | [BAAI/bge-reranker-large](https://huggingface.co/BAAI/bge-reranker-large)                                       |
 | Re-Ranking         | XLM-RoBERTa | [BAAI/bge-reranker-base](https://huggingface.co/BAAI/bge-reranker-base)                                         |
 | Re-Ranking         | GTE         | [Alibaba-NLP/gte-multilingual-reranker-base](https://huggingface.co/Alibaba-NLP/gte-multilingual-reranker-base) |
-| Re-Ranking         | ModernBert  | [Alibaba-NLP/gte-reranker-modernbert-base](https://huggingface.co/Alibaba-NLP/gte-reranker-modernbert-base) |
+| Re-Ranking         | ModernBert  | [Alibaba-NLP/gte-reranker-modernbert-base](https://huggingface.co/Alibaba-NLP/gte-reranker-modernbert-base)     |
+| Re-Ranking         | Qwen3       | [Qwen/Qwen3-Reranker-0.6B](https://huggingface.co/Qwen/Qwen3-Reranker-0.6B)                                     |
 | Sentiment Analysis | RoBERTa     | [SamLowe/roberta-base-go_emotions](https://huggingface.co/SamLowe/roberta-base-go_emotions)                     |
 
 ### Docker

--- a/backends/candle/src/models/flash_qwen3.rs
+++ b/backends/candle/src/models/flash_qwen3.rs
@@ -1,5 +1,6 @@
 use crate::flash_attn::flash_attn_varlen;
 use crate::layers::{get_cos_sin, get_inv_freqs, index_select, HiddenAct, Linear, RMSNorm};
+use crate::models::qwen3::{ClassificationHead, Qwen3ClassificationHead};
 use crate::models::{Model, Qwen3Config};
 
 use candle::{DType, Device, IndexOp, Result, Tensor};
@@ -294,6 +295,7 @@ pub struct FlashQwen3Model {
     cos_cache: Tensor,
     sin_cache: Tensor,
     pool: Pool,
+    classifier: Option<Box<dyn ClassificationHead + Send>>,
     pub device: Device,
 
     span: tracing::Span,
@@ -310,19 +312,46 @@ impl FlashQwen3Model {
             candle::bail!("FlashQwen3 requires DType::F16")
         }
 
-        let pool = match model_type {
-            ModelType::Classifier => {
-                candle::bail!("`classifier` model type is not supported for Qwen3")
-            }
-            ModelType::Embedding(pool) => pool,
-        };
-
         // The Qwen3-Reranker models contain the `model` key
         // https://huggingface.co/collections/Qwen/qwen3-reranker-6841b22d0192d7ade9cdefea
         let model_prefix = if vb.contains_tensor("model.embed_tokens.weight") {
             "model."
         } else {
             ""
+        };
+
+        let (pool, classifier) = match model_type {
+            ModelType::Classifier => {
+                // Guard against an ambiguous dual-head checkpoint: a trained `linear.weight`
+                // sequence-classification head (`num_labels`, see `projection` below) and the
+                // yes/no reranker head are mutually exclusive. Fail loudly here rather than with
+                // an opaque matmul shape error at `predict()` time.
+                if config.num_labels.is_some() && vb.contains_tensor("linear.weight") {
+                    candle::bail!(
+                        "Qwen3 checkpoint provides a trained `linear.weight` classification head \
+                         (`num_labels`), which is incompatible with the yes/no reranker head; only \
+                         one classification mechanism is supported per model."
+                    );
+                }
+
+                // Qwen3-Reranker scores the relevance of a (query, document) pair from the
+                // last token's hidden state, so we always use last-token pooling here.
+                let pool = Pool::LastToken;
+
+                // When the word embeddings are tied, the LM head shares the `embed_tokens`
+                // weights; otherwise it lives under the dedicated `lm_head` tensor.
+                let classifier_weight_name = if config.tie_word_embeddings {
+                    format!("{model_prefix}embed_tokens")
+                } else {
+                    "lm_head".to_string()
+                };
+
+                let classifier: Box<dyn ClassificationHead + Send> = Box::new(
+                    Qwen3ClassificationHead::load(vb.pp(&classifier_weight_name), config)?,
+                );
+                (pool, Some(classifier))
+            }
+            ModelType::Embedding(pool) => (pool, None),
         };
 
         let embeddings = Embedding::new(
@@ -386,6 +415,7 @@ impl FlashQwen3Model {
             cos_cache,
             sin_cache,
             pool,
+            classifier,
             device: vb.device().clone(),
             span: tracing::span!(tracing::Level::TRACE, "model"),
         })
@@ -553,5 +583,17 @@ impl Model for FlashQwen3Model {
 
     fn embed(&self, batch: Batch) -> Result<(Option<Tensor>, Option<Tensor>)> {
         self.forward(batch)
+    }
+
+    fn predict(&self, batch: Batch) -> Result<Tensor> {
+        match &self.classifier {
+            None => candle::bail!("`predict` is not implemented for this model"),
+            Some(classifier) => {
+                let (pooled_embeddings, _raw_embeddings) = self.forward(batch)?;
+                let pooled_embeddings =
+                    pooled_embeddings.expect("pooled_embeddings is empty. This is a bug.");
+                classifier.forward(&pooled_embeddings)
+            }
+        }
     }
 }

--- a/backends/candle/src/models/qwen3.rs
+++ b/backends/candle/src/models/qwen3.rs
@@ -27,6 +27,8 @@ pub struct Qwen3Config {
     pub rope_parameters: Option<RopeParameters>,
     pub sliding_window: Option<usize>,
     pub use_sliding_window: bool,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
     pub eos_token_id: usize,
     // TODO(alvarobartt): Migrate to `is_causal` instead
     // https://github.com/huggingface/transformers/pull/43705
@@ -385,6 +387,46 @@ impl Qwen3Layer {
     }
 }
 
+pub trait ClassificationHead {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor>;
+}
+
+pub struct Qwen3ClassificationHead {
+    diff_weight: Tensor,
+
+    span: tracing::Span,
+}
+
+impl Qwen3ClassificationHead {
+    pub(crate) fn load(vb: VarBuilder, config: &Qwen3Config) -> Result<Self> {
+        // Qwen3-Reranker computes its relevance score from the difference between the
+        // "yes" and "no" token logits of the language modeling head. We precompute the
+        // `yes - no` weight vector so that a single matmul over the pooled hidden state
+        // yields the score directly.
+        let yes_token_id: usize = 9693;
+        let no_token_id: usize = 2152;
+
+        let lm_head_weight = vb.get((config.vocab_size, config.hidden_size), "weight")?;
+
+        let yes_weight = lm_head_weight.i((yes_token_id, ..))?;
+        let no_weight = lm_head_weight.i((no_token_id, ..))?;
+        let diff_weight = yes_weight.sub(&no_weight)?.unsqueeze(1)?;
+
+        Ok(Self {
+            diff_weight,
+            span: tracing::span!(tracing::Level::TRACE, "classifier"),
+        })
+    }
+}
+
+impl ClassificationHead for Qwen3ClassificationHead {
+    fn forward(&self, hidden_states: &Tensor) -> Result<Tensor> {
+        let _enter = self.span.enter();
+
+        hidden_states.matmul(&self.diff_weight)
+    }
+}
+
 pub struct Qwen3Model {
     embeddings: Embedding,
     layers: Vec<Qwen3Layer>,
@@ -398,6 +440,7 @@ pub struct Qwen3Model {
     pad_token_id: u32,
 
     use_bidirectional_attention: bool,
+    classifier: Option<Box<dyn ClassificationHead + Send>>,
 
     dtype: DType,
     device: Device,
@@ -407,19 +450,46 @@ pub struct Qwen3Model {
 
 impl Qwen3Model {
     pub fn load(vb: VarBuilder, config: &Qwen3Config, model_type: ModelType) -> Result<Self> {
-        let pool = match model_type {
-            ModelType::Classifier => {
-                candle::bail!("`classifier` model type is not supported for Qwen3")
-            }
-            ModelType::Embedding(pool) => pool,
-        };
-
         // The Qwen3-Reranker models contain the `model` key
         // https://huggingface.co/collections/Qwen/qwen3-reranker-6841b22d0192d7ade9cdefea
         let model_prefix = if vb.contains_tensor("model.embed_tokens.weight") {
             "model."
         } else {
             ""
+        };
+
+        let (pool, classifier) = match model_type {
+            ModelType::Classifier => {
+                // Guard against an ambiguous dual-head checkpoint: a trained `linear.weight`
+                // sequence-classification head (`num_labels`, see `projection` below) and the
+                // yes/no reranker head are mutually exclusive. Fail loudly here rather than with
+                // an opaque matmul shape error at `predict()` time.
+                if config.num_labels.is_some() && vb.contains_tensor("linear.weight") {
+                    candle::bail!(
+                        "Qwen3 checkpoint provides a trained `linear.weight` classification head \
+                         (`num_labels`), which is incompatible with the yes/no reranker head; only \
+                         one classification mechanism is supported per model."
+                    );
+                }
+
+                // Qwen3-Reranker scores the relevance of a (query, document) pair from the
+                // last token's hidden state, so we always use last-token pooling here.
+                let pool = Pool::LastToken;
+
+                // When the word embeddings are tied, the LM head shares the `embed_tokens`
+                // weights; otherwise it lives under the dedicated `lm_head` tensor.
+                let classifier_weight_name = if config.tie_word_embeddings {
+                    format!("{model_prefix}embed_tokens")
+                } else {
+                    "lm_head".to_string()
+                };
+
+                let classifier: Box<dyn ClassificationHead + Send> = Box::new(
+                    Qwen3ClassificationHead::load(vb.pp(&classifier_weight_name), config)?,
+                );
+                (pool, Some(classifier))
+            }
+            ModelType::Embedding(pool) => (pool, None),
         };
 
         let embeddings = Embedding::new(
@@ -482,6 +552,7 @@ impl Qwen3Model {
             pad_token_id: config.eos_token_id as u32,
             num_attention_heads: config.num_attention_heads,
             use_bidirectional_attention: config.use_bidirectional_attention.unwrap_or(false),
+            classifier,
             dtype: vb.dtype(),
             device: vb.device().clone(),
             span: tracing::span!(tracing::Level::TRACE, "model"),
@@ -751,5 +822,17 @@ impl Model for Qwen3Model {
 
     fn embed(&self, batch: Batch) -> Result<(Option<Tensor>, Option<Tensor>)> {
         self.forward(batch)
+    }
+
+    fn predict(&self, batch: Batch) -> Result<Tensor> {
+        match &self.classifier {
+            None => candle::bail!("`predict` is not implemented for this model"),
+            Some(classifier) => {
+                let (pooled_embeddings, _raw_embeddings) = self.forward(batch)?;
+                let pooled_embeddings =
+                    pooled_embeddings.expect("pooled_embeddings is empty. This is a bug.");
+                classifier.forward(&pooled_embeddings)
+            }
+        }
     }
 }

--- a/backends/candle/tests/snapshots/test_qwen3__qwen3_reranker_single.snap
+++ b/backends/candle/tests/snapshots/test_qwen3__qwen3_reranker_single.snap
@@ -1,0 +1,5 @@
+---
+source: backends/candle/tests/test_qwen3.rs
+expression: predictions_single
+---
+- - -0.8051996

--- a/backends/candle/tests/test_qwen3.rs
+++ b/backends/candle/tests/test_qwen3.rs
@@ -1,8 +1,8 @@
 mod common;
 
-use crate::common::{sort_embeddings, SnapshotEmbeddings};
+use crate::common::{sort_embeddings, SnapshotEmbeddings, SnapshotScores};
 use anyhow::Result;
-use common::{batch, cosine_matcher, download_artifacts, load_tokenizer};
+use common::{batch, cosine_matcher, download_artifacts, load_tokenizer, relative_matcher};
 use text_embeddings_backend_candle::CandleBackend;
 use text_embeddings_backend_core::{Backend, ModelType, Pool};
 
@@ -47,6 +47,79 @@ fn test_qwen3() -> Result<()> {
     insta::assert_yaml_snapshot!("qwen3_cpu_single", embeddings_single, &matcher);
     assert_eq!(embeddings_batch[0], embeddings_single[0]);
     assert_eq!(embeddings_batch[2], embeddings_single[0]);
+
+    Ok(())
+}
+
+#[test]
+#[serial_test::serial]
+fn test_qwen3_reranker() -> Result<()> {
+    let (model_root, _) = download_artifacts("Qwen/Qwen3-Reranker-0.6B", None, None)?;
+    let tokenizer = load_tokenizer(&model_root)?;
+
+    let backend = CandleBackend::new(
+        &model_root,
+        "float32".to_string(),
+        ModelType::Classifier,
+        None,
+    )?;
+
+    let input_single = batch(
+        vec![tokenizer
+            .encode(("What is Deep Learning?", "Deep Learning is not..."), true)
+            .unwrap()],
+        [0].to_vec(),
+        vec![],
+    );
+
+    let predictions: Vec<Vec<f32>> = backend.predict(input_single)?.into_values().collect();
+    let predictions_single = SnapshotScores::from(predictions);
+
+    let matcher = relative_matcher();
+    insta::assert_yaml_snapshot!("qwen3_reranker_single", predictions_single, &matcher);
+
+    // Batched reranking. Positions 0 and 2 hold the SHORT pair (identical to `input_single`);
+    // position 1 holds a longer, clearly-distinct document that sets the batch `max_length`, so
+    // the short pair at 0/2 is actually left-padded. This exercises the left-padded, multi-row
+    // last-token pooling + classifier path (batch_size > 1) that the single-input test does not
+    // cover, and lets us assert that padding reproduces the unpadded single-input score.
+    let input_batch = batch(
+        vec![
+            tokenizer
+                .encode(("What is Deep Learning?", "Deep Learning is not..."), true)
+                .unwrap(),
+            tokenizer
+                .encode(
+                    (
+                        "What is Deep Learning?",
+                        "The weather in Paris is pleasant and sunny throughout the afternoon.",
+                    ),
+                    true,
+                )
+                .unwrap(),
+            tokenizer
+                .encode(("What is Deep Learning?", "Deep Learning is not..."), true)
+                .unwrap(),
+        ],
+        [0, 1, 2].to_vec(),
+        vec![],
+    );
+
+    // `predict()` keys the returned map by the 0..n output-row index (not by `pooled_indices`),
+    // so sorting by key recovers request order here because `pooled_indices` is [0, 1, 2].
+    let mut predictions: Vec<(usize, Vec<f32>)> =
+        backend.predict(input_batch)?.into_iter().collect();
+    predictions.sort_by_key(|(i, _)| *i);
+    let predictions_batch =
+        SnapshotScores::from(predictions.into_iter().map(|(_, v)| v).collect::<Vec<_>>());
+
+    // Identical (left-padded) pairs -> identical scores (positions 0 and 2).
+    assert_eq!(predictions_batch[0], predictions_batch[2]);
+    // The left-padded batch score reproduces the unpadded single-input score for the same pair.
+    assert_eq!(predictions_batch[0], predictions_single[0]);
+    // The distinct (longer, off-topic) document must NOT collapse to the same score; guards
+    // against a pooling/indexing regression that returns one row for every request.
+    assert_ne!(predictions_batch[1], predictions_batch[0]);
 
     Ok(())
 }

--- a/core/src/tokenization.rs
+++ b/core/src/tokenization.rs
@@ -325,18 +325,44 @@ fn tokenize_input(
             (Some(s), encoding)
         }
         EncodingInput::Dual(s1, s2) => {
-            if pre_prompt.is_some() {
+            // Only reranker-style prompts (e.g. Qwen3-Reranker) carry the ChatML `prefix`/`suffix`
+            // markers, which we apply as a template around the (query, document) pair. Ordinary
+            // embedding Sentence Transformers configs ship only `query`/`document` prompts (used
+            // for single-input instruction prompting) and must NOT hijack pair encoding, so the
+            // template is keyed on the reranker-specific `prefix`/`suffix` keys, not on the mere
+            // presence of a prompts map.
+            // TODO(kozistr): This could be replaced with a proper template engine if more complex
+            // prompt structures are needed in the future.
+            let reranker_prompts =
+                prompts.filter(|p| p.contains_key("prefix") || p.contains_key("suffix"));
+
+            if let Some(prompts) = reranker_prompts {
+                let prefix_prompt = prompts.get("prefix").cloned().unwrap_or_default();
+                let suffix_prompt = prompts.get("suffix").cloned().unwrap_or_default();
+                let query_prompt = prompts.get("query").cloned().unwrap_or_default();
+                let document_prompt = prompts.get("document").cloned().unwrap_or_default();
+                let s = format!(
+                    "{prefix_prompt}{query_prompt}{s1}{document_prompt}{s2}{suffix_prompt}"
+                );
+
+                (
+                    None,
+                    tokenizer
+                        .with_truncation(truncate_params)?
+                        .encode::<&str>(&s, add_special_tokens)?,
+                )
+            } else if pre_prompt.is_some() {
                 return Err(TextEmbeddingsError::Validation(
                     "`prompt_name` cannot be set with dual inputs".to_string(),
                 ));
+            } else {
+                (
+                    None,
+                    tokenizer
+                        .with_truncation(truncate_params)?
+                        .encode::<(String, String)>((s1, s2), add_special_tokens)?,
+                )
             }
-
-            (
-                None,
-                tokenizer
-                    .with_truncation(truncate_params)?
-                    .encode::<(String, String)>((s1, s2), add_special_tokens)?,
-            )
         }
         // input is encoded -> convert to tokenizers Encoding
         EncodingInput::Ids(ids) => {

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -233,7 +233,38 @@ pub async fn run(
                 .context("Failed to parse `config_sentence_transformers.json`")?,
         );
     }
-    let prompts = new_st_config.and_then(|c| c.prompts);
+    let mut prompts = new_st_config.and_then(|c| c.prompts);
+    // NOTE: Qwen3-Reranker scores a (query, document) pair through a ChatML instruction
+    // template. The checkpoint does not always ship the full
+    // `prefix`/`query`/`document`/`suffix` prompt set, so we inject/overwrite all four
+    // parts here; they are assembled around the pair in
+    // `core::tokenization`. We gate on the *resolved model type* rather than the raw
+    // architecture string, because Qwen3-Embedding shares the `Qwen3ForCausalLM` architecture
+    // identically - only a model actually detected as a classifier/reranker (CausalLM +
+    // `id2label`/`label2id`) must receive the reranker template, and we overwrite even when a
+    // partial `prompts` map is already present.
+    let is_qwen3_reranker = matches!(
+        backend_model_type,
+        text_embeddings_backend::ModelType::Classifier
+    ) && config
+        .architectures
+        .first()
+        .is_some_and(|arch| arch == "Qwen3ForCausalLM");
+    if is_qwen3_reranker {
+        let prompts_map = prompts.get_or_insert_with(HashMap::new);
+
+        let entries = [
+            ("query", "<Instruct>: Given a web search query, retrieve relevant passages that answer the query\n<Query>: "),
+            ("document", "\n<Document>: "),
+            ("prefix", "<|im_start|>system\nJudge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be \"yes\" or \"no\".<|im_end|>\n<|im_start|>user\n"),
+            ("suffix", "<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"),
+        ];
+
+        for (key, value) in entries {
+            prompts_map.insert(key.to_string(), value.to_string());
+        }
+    }
+
     let default_prompt = if let Some(default_prompt_name) = default_prompt_name.as_ref() {
         match &prompts {
             None => {
@@ -399,10 +430,25 @@ fn get_backend_model_type(
         // Edge case affecting `Alibaba-NLP/gte-multilingual-base` and possibly other fine-tunes of
         // the same base model. More context at https://huggingface.co/Alibaba-NLP/gte-multilingual-base/discussions/7
         if arch == "NewForTokenClassification"
-            && (config.id2label.is_none() | config.label2id.is_none())
+            && (config.id2label.is_none() || config.label2id.is_none())
         {
             tracing::warn!("Provided `--model-id` is likely an AlibabaNLP GTE model, but the `config.json` contains the architecture `NewForTokenClassification` but it doesn't contain the `id2label` and `label2id` mapping, so `NewForTokenClassification` architecture will be ignored.");
             continue;
+        }
+
+        // Some causal LM models can also be used as classifiers/rerankers when the `id2label` and
+        // `label2id` mappings are provided in the `config.json`, as is the case for Qwen3-Reranker
+        // (`Qwen3ForCausalLM`).
+        if arch.ends_with("CausalLM") {
+            if config.id2label.is_some() && config.label2id.is_some() {
+                tracing::warn!("Provided `--model-id` is likely a CausalLM, but the `config.json` contains the architecture `{arch}` together with the `id2label` and `label2id` mappings, so it will be treated as a classifier.");
+                return Ok(text_embeddings_backend::ModelType::Classifier);
+            }
+            // The stock Qwen3-Reranker checkpoints do not ship `id2label`/`label2id`, so without
+            // them a reranker is indistinguishable from a plain CausalLM embedding model and is
+            // loaded as an embedding model (and `/rerank` will reject it). Surface that explicitly
+            // so the failure is actionable instead of silent.
+            tracing::warn!("Architecture `{arch}` is a CausalLM without `id2label`/`label2id` in `config.json`; it will be loaded as an embedding model. If this is a reranker (e.g. Qwen3-Reranker), add `id2label`/`label2id` to `config.json` (or use a `--revision` that includes them) to enable `/rerank`.");
         }
 
         if Some(text_embeddings_backend::Pool::Splade) == pooling && arch.ends_with("MaskedLM") {


### PR DESCRIPTION
# What does this PR do?

Adds Candle backend support for Qwen3-Reranker using the official yes/no token logit-difference recipe on top of the stock Qwen3 CausalLM weights.

This is adapted from the community work in #835, with two hardening changes from review:

- preserves the existing `model.` prefix handling for Qwen3 embedding checkpoints, avoiding the `.embed_tokens.weight` regression reported on #835
- only injects the Qwen3-Reranker ChatML prompt template after the model has been resolved as a classifier, so Qwen3-Embedding models with the same `Qwen3ForCausalLM` architecture are not hijacked

Fixes #763.
Addresses #643 and #691.
Related to #835.

## Implementation notes

- Adds `Qwen3ClassificationHead`, which precomputes the `yes - no` LM-head weight vector and applies it to the pooled last-token hidden state.
- Wires `ModelType::Classifier` through both `qwen3.rs` and `flash_qwen3.rs`.
- Supports tied word embeddings via `embed_tokens` and untied weights via `lm_head`.
- Fails early for ambiguous checkpoints that include both `num_labels`/`linear.weight` and the yes/no LM-head path.
- Applies reranker prompt templating only for dual inputs when reranker-specific `prefix`/`suffix` prompts are present.

## Current model metadata caveat

The current public `Qwen/Qwen3-Reranker-0.6B` config still does not include `id2label`/`label2id`, while Qwen3 embedding and reranker configs are otherwise effectively indistinguishable. This PR keeps the classifier detection gated on those mappings and emits an explicit warning when a CausalLM lacks them. Users still need a revision/local config containing `id2label`/`label2id` for TEI to resolve it as a reranker end-to-end.

## Validation

Run locally on macOS/arm64 CPU/Candle:

```bash
cargo check -p text-embeddings-backend-candle --tests
cargo check -p text-embeddings-router --no-default-features --features candle,http
cargo test -p text-embeddings-backend-candle --test test_qwen3 -- --nocapture
cargo test -p text-embeddings-core --features text-embeddings-backend/candle,hf-hub/ureq
```

Results:

- `test_qwen3` passed, preserving `Qwen/Qwen3-Embedding-0.6B` behavior
- `test_qwen3_reranker` passed against real `Qwen/Qwen3-Reranker-0.6B` weights, including single inference plus left-padded batch invariants
- `text_embeddings_core::tokenization::tests::tokenizer` passed
- `git diff --check` clean

`cargo fmt --check` is blocked in this checkout by missing generated gRPC files (`backends/grpc-client/src/pb.rs`, `router/src/grpc/pb.rs`), so I ran `rustfmt` directly on the changed Rust files.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline?
- [x] Was this discussed/approved via a GitHub issue or the forum? See #763, #643, #691, and #835.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. @alvarobartt may have context from #763/#691.
