### PR TITLE
Add default user-agent header

### DIFF
--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -39,6 +39,9 @@ use tracing::Span;
 
 pub use logging::init_logging;
 
+const USER_AGENT_NAME: &str = "text-embeddings-inference";
+const USER_AGENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Create entrypoint
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
@@ -73,7 +76,9 @@ pub async fn run(
         // Using a local model
         (model_id_path.to_path_buf(), None)
     } else {
-        let mut builder = ApiBuilder::from_env().with_progress(false);
+        let mut builder = ApiBuilder::from_env()
+            .with_progress(false)
+            .with_user_agent(USER_AGENT_NAME, USER_AGENT_VERSION);
 
         if let Some(cache_dir) = huggingface_hub_cache {
             builder = builder.with_cache_dir(cache_dir.into());


### PR DESCRIPTION
# What does this PR do?

This PR simply adds the `text-embeddings-inference/<version>` value in the user-agent header to track downloads of models from the Hugging Face Hub with origin in this repository.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.