### PR TITLE
Align `cuda-{all-entrypoint,entrypoint}.sh`

### DIFF
--- a/cuda-all-entrypoint.sh
+++ b/cuda-all-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# GKE injects /usr/local/nvidia from the host but does not add it to PATH or
-# run ldconfig for it, unlike the nvidia-container-runtime on AWS which does both.
+# Some runtimes mount host NVIDIA tools and libraries under /usr/local/nvidia
+# without adding them to PATH or refreshing the dynamic linker cache.
 if [ -d /usr/local/nvidia/bin ]; then
     export PATH="${PATH}:/usr/local/nvidia/bin"
 fi
 if [ -d /usr/local/nvidia/lib64 ]; then
-    echo /usr/local/nvidia/lib64 > /etc/ld.so.conf.d/nvidia-host.conf
+    echo /usr/local/nvidia/lib64 >/etc/ld.so.conf.d/nvidia-host.conf
     ldconfig
 fi
 
@@ -20,7 +20,8 @@ fi
 # version is lower than that; whilst we shouldn't include that when CUDA is 13.0+
 # as otherwise it will fail due to it.
 if [ -d /usr/local/cuda/compat ]; then
-    DRIVER_CUDA=$(nvidia-smi 2>/dev/null | awk '/CUDA Version/ {print $3; exit}')
+    # Match both "CUDA Version" and "CUDA UMD Version" (on `driver-6xx` onwards)
+    DRIVER_CUDA=$(nvidia-smi 2>/dev/null | grep -oE 'CUDA[[:space:]]+([A-Za-z]+[[:space:]])?Version:[[:space:]]*[0-9]+(\.[0-9]+)+' | grep -oE '[0-9]+(\.[0-9]+)+' | head -n1)
 
     IFS='.' read -r MAJ MIN PATCH <<EOF
 ${DRIVER_CUDA:-0.0.0}

--- a/cuda-entrypoint.sh
+++ b/cuda-entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# GKE injects /usr/local/nvidia from the host but does not add it to PATH or
-# run ldconfig for it, unlike the nvidia-container-runtime on AWS which does both.
+# Some runtimes mount host NVIDIA tools and libraries under /usr/local/nvidia
+# without adding them to PATH or refreshing the dynamic linker cache.
 if [ -d /usr/local/nvidia/bin ]; then
     export PATH="${PATH}:/usr/local/nvidia/bin"
 fi
 if [ -d /usr/local/nvidia/lib64 ]; then
-    echo /usr/local/nvidia/lib64 > /etc/ld.so.conf.d/nvidia-host.conf
+    echo /usr/local/nvidia/lib64 >/etc/ld.so.conf.d/nvidia-host.conf
     ldconfig
 fi
 


### PR DESCRIPTION
# What does this PR do?

This PR is a follow-up of both #870 as it updates the `DRIVER_VERSION` but only on `cuda-entrypoint.sh` and not `cuda-all-entrypoint.sh`, and #877 to make the comment cloud-agnostic, but rather explaining the issue per-se.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.