### PR TITLE
Add `--root-path` to specificy HTTP prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,15 @@ Options:
           [env: PORT=]
           [default: 3000]
 
+      --root-path <ROOT_PATH>
+          Root path to mount all HTTP routes under.
+
+          For example, `--root-path jinaai/jina-embeddings-v2-base-en` serves the OpenAI-compatible embeddings route at `/jinaai/jina-embeddings-v2-base-en/v1/embeddings`.
+
+          Unused for gRPC servers.
+
+          [env: ROOT_PATH=]
+
       --uds-path <UDS_PATH>
           The name of the unix socket some text-embeddings-inference backends will use as they communicate internally with gRPC
 

--- a/docs/source/en/cli_arguments.md
+++ b/docs/source/en/cli_arguments.md
@@ -150,6 +150,15 @@ Options:
           [env: PORT=]
           [default: 3000]
 
+      --root-path <ROOT_PATH>
+          Root path to mount all HTTP routes under.
+
+          For example, `--root-path jinaai/jina-embeddings-v2-base-en` serves the OpenAI-compatible embeddings route at `/jinaai/jina-embeddings-v2-base-en/v1/embeddings`.
+
+          Unused for gRPC servers.
+
+          [env: ROOT_PATH=]
+
       --uds-path <UDS_PATH>
           The name of the unix socket some text-embeddings-inference backends will use as they communicate internally with gRPC
 

--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -1624,6 +1624,7 @@ async fn metrics(prom_handle: Extension<PrometheusHandle>) -> String {
 }
 
 /// Serving method
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     infer: Infer,
     info: Info,

--- a/router/src/http/server.rs
+++ b/router/src/http/server.rs
@@ -1632,6 +1632,7 @@ pub async fn run(
     payload_limit: usize,
     api_key: Option<String>,
     cors_allow_origin: Option<Vec<String>>,
+    root_path: Option<String>,
 ) -> Result<(), anyhow::Error> {
     // OpenAPI documentation
     #[derive(OpenApi)]
@@ -1872,6 +1873,14 @@ pub async fn run(
         .layer(DefaultBodyLimit::max(payload_limit))
         .layer(cors_layer);
 
+    let app = match normalize_root_path(root_path.as_deref())? {
+        Some(root_path) => {
+            tracing::info!("Serving HTTP routes under root path: {root_path}");
+            Router::new().nest(&root_path, app)
+        }
+        None => app,
+    };
+
     // Run server
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
@@ -1886,6 +1895,24 @@ pub async fn run(
         .await?;
 
     Ok(())
+}
+
+fn normalize_root_path(root_path: Option<&str>) -> Result<Option<String>, anyhow::Error> {
+    let Some(root_path) = root_path else {
+        return Ok(None);
+    };
+
+    let root_path = root_path.trim();
+    if root_path.is_empty() || root_path == "/" {
+        return Ok(None);
+    }
+
+    if root_path.contains('?') || root_path.contains('#') {
+        anyhow::bail!("`--root-path` must be a path and cannot contain `?` or `#`");
+    }
+
+    let root_path = format!("/{}", root_path.trim_matches('/'));
+    Ok(Some(root_path))
 }
 
 impl From<&ErrorType> for StatusCode {
@@ -1930,5 +1957,36 @@ impl From<serde_json::Error> for ErrorResponse {
             error: err.to_string(),
             error_type: ErrorType::Validation,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_root_path;
+
+    #[test]
+    fn normalize_root_path_ignores_empty_and_root() {
+        assert_eq!(normalize_root_path(None).unwrap(), None);
+        assert_eq!(normalize_root_path(Some("")).unwrap(), None);
+        assert_eq!(normalize_root_path(Some("   ")).unwrap(), None);
+        assert_eq!(normalize_root_path(Some("/")).unwrap(), None);
+    }
+
+    #[test]
+    fn normalize_root_path_adds_leading_slash_and_trims_trailing_slashes() {
+        assert_eq!(
+            normalize_root_path(Some("jinaai/jina-embeddings-v2-base-en")).unwrap(),
+            Some("/jinaai/jina-embeddings-v2-base-en".to_string())
+        );
+        assert_eq!(
+            normalize_root_path(Some("/jinaai/jina-embeddings-v2-base-en/")).unwrap(),
+            Some("/jinaai/jina-embeddings-v2-base-en".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_root_path_rejects_query_and_fragment() {
+        assert!(normalize_root_path(Some("/foo?bar")).is_err());
+        assert!(normalize_root_path(Some("/foo#bar")).is_err());
     }
 }

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -62,6 +62,7 @@ pub async fn run(
     hf_token: Option<String>,
     hostname: Option<String>,
     port: u16,
+    root_path: Option<String>,
     uds_path: Option<String>,
     huggingface_hub_cache: Option<String>,
     payload_limit: usize,
@@ -390,15 +391,17 @@ pub async fn run(
             payload_limit,
             api_key,
             cors_allow_origin,
+            root_path,
         )
         .await
     }
 
     #[cfg(feature = "grpc")]
     {
-        // cors_allow_origin and payload_limit are not used for gRPC servers
+        // cors_allow_origin, payload_limit and root_path are not used for gRPC servers
         let _ = cors_allow_origin;
         let _ = payload_limit;
+        let _ = root_path;
         grpc::server::run(infer, info, addr, prom_builder, api_key).await
     }
 }

--- a/router/src/main.rs
+++ b/router/src/main.rs
@@ -151,6 +151,15 @@ struct Args {
     #[clap(default_value = "3000", long, short, env)]
     port: u16,
 
+    /// Root path to mount all HTTP routes under.
+    ///
+    /// For example, `--root-path jinaai/jina-embeddings-v2-base-en` serves the
+    /// OpenAI-compatible embeddings route at `/jinaai/jina-embeddings-v2-base-en/v1/embeddings`.
+    ///
+    /// Unused for gRPC servers.
+    #[clap(long, env)]
+    root_path: Option<String>,
+
     /// The name of the unix socket some text-embeddings-inference backends will use as they
     /// communicate internally with gRPC.
     #[clap(default_value = "/tmp/text-embeddings-inference-server", long, env)]
@@ -258,6 +267,7 @@ async fn main() -> Result<()> {
         token,
         Some(args.hostname),
         args.port,
+        args.root_path,
         Some(args.uds_path),
         args.huggingface_hub_cache,
         args.payload_limit,

--- a/router/tests/common.rs
+++ b/router/tests/common.rs
@@ -65,6 +65,7 @@ pub async fn start_server(model_id: String, revision: Option<String>, dtype: DTy
             8090,
             None,
             None,
+            None,
             2_000_000,
             None,
             None,


### PR DESCRIPTION
# What does this PR do?

This PR adds the `--root-path` argument so that users can specify the prefix for the HTTP API, similarly as in vLLM with FastAPI, so that instead of having http://localhost:3000/v1/embeddings, one might set `--root-path jinaai/jina-embeddings-v2-base-en` meaning the HTTP routes are behind http://localhost:3000/jinaai/jina-embeddings-v2-base-en instead so that the OpenAI Embeddings API sits in http://localhost:3000/jinaai/jina-embeddings-v2-base-en/v1/embeddings.

Closes #888 

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs).
- [x] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.