### PR TITLE
docs: warn that cuda-1.9 image + flash-attn silently produces NaN embeddings on Turing/T4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Notes for coding agents (and humans) deploying or benchmarking Text Embeddings Inference (TEI)
+on GPU hardware, especially NVIDIA Turing (T4, RTX 2000 series, ...).
+
+## Turing (T4) GPUs: avoid the `cuda-1.9` quickstart image without an explicit Flash Attention override
+
+The README's headline Docker quickstart uses the multi-architecture
+`ghcr.io/huggingface/text-embeddings-inference:cuda-1.9` image. On Turing GPUs this image
+correctly auto-detects the architecture and dispatches the Turing-compatible binary, but it still
+starts with `USE_FLASH_ATTENTION=True` by default — that default is baked in at build time and is
+not adjusted per-architecture the way the binary selection is.
+
+This has been observed on real T4 hardware to go beyond the "precision issues" mentioned in the
+README's Docker Images table: the server starts cleanly, responds HTTP 200 with `Success` logged
+for every request, and returns embedding vectors that are **entirely NaN** — with no warning or
+error surfaced anywhere. This was reproduced across two unrelated model architectures
+(`Qwen/Qwen3-Embedding-0.6B` and `BAAI/bge-small-en-v1.5`), 3+ runs each, 100% reproduction rate.
+
+**If you are deploying on a Turing GPU:**
+- Prefer the dedicated `turing-1.9` image, which defaults to `USE_FLASH_ATTENTION=False`, or
+- If you must use `cuda-1.9`, explicitly pass `-e USE_FLASH_ATTENTION=False`.
+
+Do not rely on the absence of errors/warnings as a signal that flash attention is safe on Turing —
+in the broken configuration there is no signal at all; the only symptom is corrupted output.
+
+## Turning Flash Attention off can trigger an OOM at the default `--max-batch-tokens`
+
+Once Flash Attention is disabled (either via `turing-1.9` or `USE_FLASH_ATTENTION=False`), some
+models can fail to start with:
+
+```
+Error: Model backend is not healthy
+
+Caused by:
+    DriverError(CUDA_ERROR_OUT_OF_MEMORY, "out of memory")
+```
+
+This was reproduced with `Qwen/Qwen3-Embedding-0.6B` at the default `--max-batch-tokens=16384` on
+a 16GB T4 (the non-flash attention path appears to require materializing larger intermediate
+tensors during warmup). `BAAI/bge-small-en-v1.5`, whose default `--max-batch-tokens` is much
+smaller (512), did not hit this.
+
+If you hit an OOM after disabling Flash Attention, lower `--max-batch-tokens` (e.g. `2048`) rather
+than assuming the GPU is undersized — peak steady-state VRAM for these models is well under 2GB on
+a 16GB T4.
+
+## dtype defaults are already safe on this GPU family
+
+TEI's GPU default dtype is `float16`; there is no `bfloat16` code path in the candle backend, so
+the common "silent bf16 fallback" trap seen in other inference servers does not apply here.
+`--dtype float32` is available if needed, but on T4 `float16` measured ~18% faster and ~23% lower
+VRAM than `float32` for the same model.
+
+## `--quantize` is not a real TEI CLI flag
+
+`int8` quantization and CUDA graphs have no implementation in this codebase (not "supported but
+broken" — simply absent). One doc page previously referenced a `--quantize` CLI flag that does not
+exist in `docs/source/en/cli_arguments.md` or in `router/src/main.rs`; that reference has been
+removed. Don't add code assuming `--quantize` exists without first adding the feature itself.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,18 @@ volume=$PWD/data # share a volume with the Docker container to avoid downloading
 docker run --gpus all -p 8080:80 -v $volume:/data --pull always ghcr.io/huggingface/text-embeddings-inference:cuda-1.9 --model-id $model
 ```
 
+> [!WARNING]
+> **Turing GPUs (T4, RTX 2000 series, ...):** the `cuda-1.9` image above auto-detects your GPU
+> architecture and dispatches the correct binary, but it always starts with
+> `USE_FLASH_ATTENTION=True` regardless of architecture. On Turing this is not just a precision
+> hit — it has been observed to silently produce **100% NaN embeddings while the server still
+> returns HTTP 200 "Success" with no warnings or errors**. If you are running on a Turing GPU,
+> either use the dedicated `turing-1.9` image (see [Docker Images](#docker-images)) or add
+> `-e USE_FLASH_ATTENTION=False` to the command above. Note that disabling Flash Attention can
+> increase memory usage during warmup; if you hit a CUDA out-of-memory error, also lower
+> `--max-batch-tokens` (e.g. `--max-batch-tokens 2048`) or use the `turing-1.9` image, which does
+> not require any of these overrides.
+
 And then you can make requests like
 
 ```bash
@@ -351,8 +363,17 @@ Text Embeddings Inference ships with multiple Docker images that you can use to 
 | Blackwell 12.0 (GeForce RTX 50X0, ...) | x86_64   | ghcr.io/huggingface/text-embeddings-inference:120-1.9 (experimental)    |
 | Blackwell 12.1 (DGX Spark GB10, ...)   | multi    | ghcr.io/huggingface/text-embeddings-inference:121-1.9 (experimental)    |
 
-**Warning**: Flash Attention is turned off by default for the Turing image as it suffers from precision issues.
-You can turn Flash Attention v1 ON by using the `USE_FLASH_ATTENTION=True` environment variable.
+**Warning**: Flash Attention is turned off by default for the Turing image (`turing-1.9`) as it
+suffers from precision issues. You can turn Flash Attention v1 ON by using the
+`USE_FLASH_ATTENTION=True` environment variable.
+
+This warning also applies to the multi-architecture `cuda-1.9` image used in the
+[Docker quickstart](#docker) above: on Turing GPUs (T4, RTX 2000 series, ...) it correctly
+dispatches to the Turing binary, but it still defaults to `USE_FLASH_ATTENTION=True` since that
+default is baked in at build time and is not adjusted per-architecture. In practice this has been
+observed to go beyond "precision issues" and produce fully NaN embedding outputs with no error
+reported. Turing users should prefer the dedicated `turing-1.9` image, or explicitly pass
+`-e USE_FLASH_ATTENTION=False` when using `cuda-1.9`.
 
 ### API documentation
 

--- a/docs/source/en/tei_cloud_run.md
+++ b/docs/source/en/tei_cloud_run.md
@@ -73,7 +73,6 @@ The command needs you to specify the following parameters:
 - `--image`: The container image URI to deploy.
 - `--args`: The arguments to pass to the container entrypoint, being `text-embeddings-inference` for the Hugging Face DLC for TEI. Read more about the supported arguments [here](https://huggingface.co/docs/text-embeddings-inference/cli_arguments).
   - `--model-id`: The model ID to use, in this case, [`ibm-granite/granite-embedding-278m-multilingual`](https://huggingface.co/ibm-granite/granite-embedding-278m-multilingual).
-  - `--quantize`: The quantization method to use. If not specified, it will be retrieved from the `quantization_config->quant_method` in the `config.json` file.
   - `--max-concurrent-requests`: The maximum amount of concurrent requests for this particular deployment. Having a low limit will refuse clients requests instead of having them wait for too long and is usually good to handle back pressure correctly. Set to 64, but default is 128.
 - `--port`: The port the container listens to.
 - `--cpu` and `--memory`: The number of CPUs and amount of memory to allocate to the container. Needs to be set to 4 and 16Gi (16 GiB), respectively; as that's the minimum requirement for using the GPU.


### PR DESCRIPTION
## What does this PR do?

**Motivation:** The README's own headline "Docker" quickstart command uses the `cuda-1.9`
multi-architecture image. On a real Tesla T4 (Turing, 16GB), this image correctly auto-detects
the GPU and dispatches the Turing-compatible binary (`text-embeddings-router-75`), but it still
starts with `USE_FLASH_ATTENTION=True` — that default is baked in at build time
(`Dockerfile-cuda-all`'s `ARG DEFAULT_USE_FLASH_ATTENTION=True`) and is not adjusted per
architecture the way the binary selection is (only the `turing` build in
`.github/workflows/matrix.json` overrides it to `False`).

This is more severe than the "precision issues" the README's own "Docker Images" table already
warns about for the Turing image: on a T4, the exact quickstart command from the README's
headline section produces **100% NaN embedding vectors**, while the server logs
`router/src/http/server.rs:737: Success` and returns HTTP 200 for every request — no error or
warning anywhere. A production user following the README verbatim on a T4 would silently write
corrupted (all-`null`) embeddings into their vector store.

**Repro (real Tesla T4, driver 550.163.01, Docker 24.0.9-1, TEI 1.9.3):**
- Image: `ghcr.io/huggingface/text-embeddings-inference:cuda-1.9` (sha256:249a0bc8...)
- Command: exactly the README headline command, unmodified:
  `docker run --gpus all -p 8080:80 -v $volume:/data ghcr.io/huggingface/text-embeddings-inference:cuda-1.9 --model-id $model`
- `docker exec <container> env | grep FLASH` → `USE_FLASH_ATTENTION=True`
- `curl 127.0.0.1:8080/embed -d '{"inputs":"What is Deep Learning?"}'` →
  `[[null,null,null,...]]` (all dimensions NaN), HTTP 200
- Reproduced on two unrelated model architectures — `Qwen/Qwen3-Embedding-0.6B` (1024-dim) and
  `BAAI/bge-small-en-v1.5` (384-dim) — 3+ runs each, 100% reproduction rate
- Adding `-e USE_FLASH_ATTENTION=False`, or switching to the `turing-1.9` image
  (sha256:dee4a149..., which defaults to `USE_FLASH_ATTENTION=False`), immediately produces
  normalized, valid embeddings (norm≈1.0) for both models — confirmed by A/B toggle on the same
  hardware/model/input.
- Secondary trap: once Flash Attention is disabled, `Qwen/Qwen3-Embedding-0.6B` fails to start at
  the default `--max-batch-tokens=16384` with `DriverError(CUDA_ERROR_OUT_OF_MEMORY, "out of
  memory")` during warmup; lowering to `--max-batch-tokens 2048` fixes it. (`bge-small`'s default
  of 512 doesn't hit this.)

**Changes:**
1. README: add a prominent warning directly under the headline Docker quickstart command,
   telling Turing/T4 users to use `turing-1.9` or set `-e USE_FLASH_ATTENTION=False`, and noting
   the `--max-batch-tokens` OOM trap that can follow.
2. README: extend the existing "Docker Images" table warning (currently phrased as if it only
   applies to the dedicated `turing-1.9` image) to make clear it also applies to the `cuda-1.9`
   image used in the quickstart, which is not listed in that table at all.
3. New `AGENTS.md` summarizing this and the other T4-relevant findings from this session
   (flash-attn default risk + fix, the `--max-batch-tokens` OOM trap, and that TEI's default
   dtype — float16, no bf16 code path — is already safe on Turing).
4. `docs/source/en/tei_cloud_run.md`: remove a `--quantize` CLI flag reference that does not
   exist in `docs/source/en/cli_arguments.md` or `router/src/main.rs` (0 matches in either) —
   likely copied over from TGI's docs, which does have this flag.

**No code changes** — this is a documentation-only PR. It does not change any default behavior,
Dockerfile build args, or entrypoint logic; it only documents what the current images already do.
I'm separately considering whether to open a follow-up issue proposing that
`cuda-all-entrypoint.sh` pick a safe `USE_FLASH_ATTENTION` default based on the `compute_cap` it
already detects, since that would be a code change and is out of scope here.

**AI disclosure:** I used an AI coding assistant to help investigate this (including running the
repro on a real T4) and draft this PR description. I read and verified the diff and the repro
steps myself before submitting.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/text-embeddings-inference/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? If applicable, did you include or update the `insta` snapshots?

## Who can review?

@Narsil @alvarobartt
