### PR TITLE
Fix Cloud Run CLI argument documentation

### DIFF
--- a/docs/source/en/tei_cloud_run.md
+++ b/docs/source/en/tei_cloud_run.md
@@ -73,8 +73,7 @@ The command needs you to specify the following parameters:
 - `--image`: The container image URI to deploy.
 - `--args`: The arguments to pass to the container entrypoint, being `text-embeddings-inference` for the Hugging Face DLC for TEI. Read more about the supported arguments [here](https://huggingface.co/docs/text-embeddings-inference/cli_arguments).
   - `--model-id`: The model ID to use, in this case, [`ibm-granite/granite-embedding-278m-multilingual`](https://huggingface.co/ibm-granite/granite-embedding-278m-multilingual).
-  - `--quantize`: The quantization method to use. If not specified, it will be retrieved from the `quantization_config->quant_method` in the `config.json` file.
-  - `--max-concurrent-requests`: The maximum amount of concurrent requests for this particular deployment. Having a low limit will refuse clients requests instead of having them wait for too long and is usually good to handle back pressure correctly. Set to 64, but default is 128.
+  - `--max-concurrent-requests`: The maximum amount of concurrent requests for this particular deployment. Having a low limit will refuse clients requests instead of having them wait for too long and is usually good to handle back pressure correctly. Set to 64, but default is 512.
 - `--port`: The port the container listens to.
 - `--cpu` and `--memory`: The number of CPUs and amount of memory to allocate to the container. Needs to be set to 4 and 16Gi (16 GiB), respectively; as that's the minimum requirement for using the GPU.
 - `--no-cpu-throttling`: Disables CPU throttling, which is required for using the GPU.


### PR DESCRIPTION
# What does this PR do?

Updates the Cloud Run deployment guide to match the current TEI router CLI:

- removes the `--quantize` entry, since the router does not expose that argument
- corrects the documented `--max-concurrent-requests` default from 128 to 512

This only changes documentation and adds no dependencies.

Validation:

- compared the guide against `router/src/main.rs` and `docs/source/en/cli_arguments.md`
- checked that the stale default and unsupported argument no longer appear in the guide
- ran `git diff --check`

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that is the case).
- [x] Did you read the contributor guideline?
- [x] Did you make sure to update the documentation with your changes?
- [x] No runtime tests are needed for this documentation-only change.